### PR TITLE
Use canonical owner casing for git push and API calls

### DIFF
--- a/gh_safe_repo/commands/create.py
+++ b/gh_safe_repo/commands/create.py
@@ -90,6 +90,9 @@ def run(args):
     client = ctx.client
     is_paid_plan = ctx.is_paid_plan
 
+    # Git push URLs are case-sensitive; redirected pushes reject workflow files.
+    owner = ctx.owner
+
     # Apply CLI overrides
     overrides = {}
     if args.public:

--- a/gh_safe_repo/commands/fix.py
+++ b/gh_safe_repo/commands/fix.py
@@ -60,8 +60,6 @@ def run(args):
     json_mode = args.json
     _info = lambda msg: info(msg, json_mode=json_mode)
 
-    _info(f"\nAuditing {_BOLD}{owner}/{repo_name}{_RESET}...")
-
     # Verify repo exists and fetch its data
     try:
         repo_data = client.get_repo_data(owner, repo_name)
@@ -80,6 +78,14 @@ def run(args):
         full_name = repo_data.get("full_name", f"{owner}/{repo_name}")
         owner_type = repo_data.get("owner", {}).get("type", "unknown")
         print(f"[debug] repo: {full_name} (id={repo_id}, owner_type={owner_type})", file=sys.stderr)
+
+    # Use canonical casing from the API; `fix` accepts org/collaborator repos.
+    canonical_owner = repo_data.get("owner", {}).get("login")
+    canonical_name = repo_data.get("name")
+    if canonical_owner and canonical_name:
+        owner, repo_name = canonical_owner, canonical_name
+
+    _info(f"\nAuditing {_BOLD}{owner}/{repo_name}{_RESET}...")
 
     # Verify the authenticated user has admin access (required to change settings)
     if not repo_data.get("permissions", {}).get("admin", False):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,6 +180,91 @@ class TestCreateFlagValidation:
                 main()
         assert exc_info.value.code == 2
 
+    def test_push_local_called_with_canonical_owner(self, tmp_path):
+        """Direct coverage: client.push_local must receive ctx.owner, not the typed owner.
+
+        This was the actual bug — a typed lowercase owner produced a redirected
+        push URL, which GitHub rejects for repos containing workflow files.
+        """
+        mock_client = MagicMock()
+        mock_client.check_repo_exists.return_value = False
+        # Successful repo create response
+        mock_client.call_json.return_value = {"default_branch": "main"}
+
+        with patch("sys.argv", [
+            "gh-safe-repo", "create", "ariesq/my-repo", "--local", str(tmp_path), "--yes",
+        ]):
+            with patch("gh_safe_repo.commands.create.build_context") as mock_ctx, \
+                 patch("gh_safe_repo.commands.create.check_repo_exists", return_value=False), \
+                 patch("gh_safe_repo.commands.create.run_preflight_scan_local", return_value=True), \
+                 patch("gh_safe_repo.commands.create.RepositoryPlugin") as MockRepo, \
+                 patch("gh_safe_repo.commands.create.ActionsPlugin"), \
+                 patch("gh_safe_repo.commands.create.BranchProtectionPlugin"), \
+                 patch("gh_safe_repo.commands.create.SecurityPlugin"), \
+                 patch("gh_safe_repo.commands.create.TagProtectionPlugin"):
+                MockRepo.return_value = MagicMock(created_default_branch="main")
+                mock_ctx.return_value = MagicMock(
+                    client=mock_client, owner="AriESQ", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+        mock_client.push_local.assert_called_once()
+        call_owner = mock_client.push_local.call_args[0][1]
+        assert call_owner == "AriESQ"
+
+    def test_plugins_constructed_with_canonical_owner(self, tmp_path):
+        """Plugin constructors must receive the canonical owner for API paths."""
+        mock_client = MagicMock()
+
+        with patch("sys.argv", [
+            "gh-safe-repo", "create", "ariesq/my-repo", "--dry-run",
+        ]):
+            with patch("gh_safe_repo.commands.create.build_context") as mock_ctx, \
+                 patch("gh_safe_repo.commands.create.RepositoryPlugin") as MockRepo, \
+                 patch("gh_safe_repo.commands.create.ActionsPlugin") as MockActions, \
+                 patch("gh_safe_repo.commands.create.BranchProtectionPlugin") as MockBP, \
+                 patch("gh_safe_repo.commands.create.SecurityPlugin") as MockSec, \
+                 patch("gh_safe_repo.commands.create.TagProtectionPlugin") as MockTag:
+                for M in (MockRepo, MockActions, MockBP, MockSec, MockTag):
+                    M.return_value = MagicMock()
+                    M.return_value.plan.return_value = Plan()
+                mock_ctx.return_value = MagicMock(
+                    client=mock_client, owner="AriESQ", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+        for M in (MockRepo, MockActions, MockBP, MockSec, MockTag):
+            assert M.call_args[0][1] == "AriESQ", \
+                f"{M} called with non-canonical owner: {M.call_args}"
+
+    def test_uses_canonical_owner_casing_in_plan(self, capsys):
+        """User types 'ariesq/repo' but ctx.owner is 'AriESQ' — plan must show canonical casing.
+
+        Git push URLs are case-sensitive; redirected pushes are rejected for workflow files.
+        """
+        with patch("sys.argv", [
+            "gh-safe-repo", "create", "ariesq/my-repo", "--dry-run",
+        ]):
+            with patch("gh_safe_repo.commands.create.build_context") as mock_ctx:
+                mock_ctx.return_value = MagicMock(
+                    client=MagicMock(), owner="AriESQ", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "AriESQ/my-repo" in out
+        assert "ariesq/my-repo" not in out
+
 
 class TestFixFlagValidation:
     def test_bare_repo_name_exits(self):
@@ -208,6 +293,78 @@ class TestFixFlagValidation:
                 with pytest.raises(SystemExit) as exc_info:
                     main()
                 assert exc_info.value.code == 1
+
+    def test_plugins_constructed_with_canonical_owner(self):
+        """fix plugins must receive the canonical owner derived from repo_data."""
+        with patch("sys.argv", [
+            "gh-safe-repo", "fix", "some-org/some-repo", "--dry-run",
+        ]):
+            with patch("gh_safe_repo.commands.fix.build_context") as mock_ctx, \
+                 patch("gh_safe_repo.commands.fix.RepositoryPlugin") as MockRepo, \
+                 patch("gh_safe_repo.commands.fix.ActionsPlugin") as MockActions, \
+                 patch("gh_safe_repo.commands.fix.BranchProtectionPlugin") as MockBP, \
+                 patch("gh_safe_repo.commands.fix.SecurityPlugin") as MockSec, \
+                 patch("gh_safe_repo.commands.fix.TagProtectionPlugin") as MockTag:
+                for M in (MockRepo, MockActions, MockBP, MockSec, MockTag):
+                    M.return_value = MagicMock()
+                    M.return_value.plan.return_value = Plan()
+                    M.return_value.fetch_current_state.return_value = {}
+                mock_client = MagicMock()
+                mock_client.get_repo_data.return_value = {
+                    "id": 123,
+                    "full_name": "Some-Org/Some-Repo",
+                    "name": "Some-Repo",
+                    "owner": {"login": "Some-Org", "type": "Organization"},
+                    "private": False,
+                    "default_branch": "main",
+                    "permissions": {"admin": True, "push": True, "pull": True},
+                }
+                mock_ctx.return_value = MagicMock(
+                    client=mock_client, owner="myuser", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+        for M in (MockRepo, MockActions, MockBP, MockSec, MockTag):
+            args_, _kw = M.call_args
+            assert args_[1] == "Some-Org" and args_[2] == "Some-Repo", \
+                f"{M} called with non-canonical owner/repo: {args_}"
+
+    def test_uses_canonical_owner_casing_from_repo_data(self, capsys):
+        """fix should canonicalize owner/repo casing from the GET /repos response.
+
+        `fix` accepts org/collaborator repos, so it cannot use ctx.owner — it must
+        derive canonical casing from repo_data['owner']['login'] and repo_data['name'].
+        """
+        with patch("sys.argv", [
+            "gh-safe-repo", "fix", "some-org/some-repo", "--dry-run",
+        ]):
+            with patch("gh_safe_repo.commands.fix.build_context") as mock_ctx:
+                mock_client = MagicMock()
+                mock_client.get_repo_data.return_value = {
+                    "id": 123,
+                    "full_name": "Some-Org/Some-Repo",
+                    "name": "Some-Repo",
+                    "owner": {"login": "Some-Org", "type": "Organization"},
+                    "private": False,
+                    "default_branch": "main",
+                    "permissions": {"admin": True, "push": True, "pull": True},
+                }
+                mock_client.call_api.return_value = (200, "{}")
+                mock_ctx.return_value = MagicMock(
+                    client=mock_client, owner="myuser", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                try:
+                    main()
+                except SystemExit:
+                    pass
+        out = capsys.readouterr().out
+        assert "Some-Org/Some-Repo" in out
+        assert "some-org/some-repo" not in out
 
     def test_admin_permission_proceeds(self):
         """fix should allow repos where the user has admin permissions (no exit at permission check)."""


### PR DESCRIPTION
## Summary
- Git push URLs are case-sensitive: typing `myuser/repo` when the authenticated login is `MyUser` causes GitHub to redirect the push, and pushes to the redirected URL are rejected for repos containing workflow files (`refusing to allow an OAuth App to create or update workflow ... without 'workflow' scope`).
- `create`: reassign `owner = ctx.owner` after `build_context` so `client.push_local`, plugin constructors, and plan output all use the canonical login.
- `fix`: canonicalize from the `GET /repos` response (`repo_data["owner"]["login"]` and `repo_data["name"]`) — `ctx.owner` isn't usable here because `fix` accepts org/collaborator repos. Moved the "Auditing …" message to print after canonicalization.
- `scan` requires no change (local path only, no GitHub interaction).

## Test plan
- [x] `uv run pytest tests/ -v` — 487 passed, 7 skipped
- [x] New: `client.push_local` is called with the canonical owner casing
- [x] New: all 5 plugins in `create` are constructed with the canonical owner
- [x] New: all 5 plugins in `fix` are constructed with the canonical owner+name from `repo_data`
- [x] New: plan/audit output shows canonical casing
- [ ] Manual: re-run `gh-safe-repo create <user>/<repo> --local .` with a case-mismatched typed owner and confirm the push no longer redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)