### PR TITLE
Prioritize GITHUB_TOKEN env var over gh auth token

### DIFF
--- a/gh_safe_repo/github_client.py
+++ b/gh_safe_repo/github_client.py
@@ -1,6 +1,6 @@
 """
 GitHub API client wrapping `gh api` via subprocess.
-Auth priority: gh auth token > GITHUB_TOKEN env var > error.
+Auth priority: GITHUB_TOKEN env var > gh auth token > error.
 
 Git transport (push/clone/preflight) lives in git_transport.GitTransport.
 Callers must assign `self.transport` before invoking copy_repo / push_local /
@@ -39,7 +39,14 @@ class GitHubClient:
         return self.transport
 
     def _authenticate(self):
-        # Try gh CLI first
+        # GITHUB_TOKEN env var takes priority — lets callers target a specific
+        # account without switching the active gh session.
+        token = os.environ.get("GITHUB_TOKEN", "")
+        if token:
+            self._token = token
+            return
+
+        # Fall back to the active gh CLI session.
         result = subprocess.run(
             ["gh", "auth", "token"],
             capture_output=True,
@@ -51,12 +58,6 @@ class GitHubClient:
                 self._token = token
                 self._use_gh = True
                 return
-
-        # Fall back to GITHUB_TOKEN env var
-        token = os.environ.get("GITHUB_TOKEN", "")
-        if token:
-            self._token = token
-            return
 
         raise AuthError(
             "No GitHub credentials found. "

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -32,20 +32,22 @@ def make_completed_process(stdout="", stderr="", returncode=0):
 
 
 class TestAuthentication:
-    def test_uses_gh_cli_token(self):
+    def test_env_var_takes_priority_over_gh_cli(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "env_token_abc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = make_completed_process(stdout="ghp_cli_token\n")
+            client = GitHubClient()
+            assert client._use_gh is False
+            assert client._token == "env_token_abc"
+            mock_run.assert_not_called()
+
+    def test_uses_gh_cli_token_when_no_env_var(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = make_completed_process(stdout="ghp_token123\n")
             client = GitHubClient()
             assert client._use_gh is True
             assert client._token == "ghp_token123"
-
-    def test_falls_back_to_env_var(self, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "env_token_abc")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = make_completed_process(returncode=1, stdout="")
-            client = GitHubClient()
-            assert client._use_gh is False
-            assert client._token == "env_token_abc"
 
     def test_raises_auth_error_with_no_credentials(self, monkeypatch):
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)


### PR DESCRIPTION
## Summary

- Flips auth resolution order in `GitHubClient._authenticate`: `GITHUB_TOKEN` env var is now checked before `gh auth token`
- Enables targeting a specific account (e.g. `rootnotez`) via `GITHUB_TOKEN=$(gh auth token --user rootnotez)` without switching the active gh session
- Updates `TestAuthentication` to assert the new priority and that `subprocess.run` is not called when env var is set

## Test plan

- [ ] `uv run pytest tests/test_github_client.py::TestAuthentication -v` — all 3 pass
- [ ] `uv run pytest tests/ --ignore=tests/e2e` — all 491 pass
- [ ] Manual: `GITHUB_TOKEN=$(gh auth token --user rootnotez) gh-safe-repo create rootnotez/<repo> --dry-run` resolves as rootnotez without switching active account

🤖 Generated with [Claude Code](https://claude.com/claude-code)