### PR TITLE
Show set-upstream hint instead of git remote add for --local creates

### DIFF
--- a/gh_safe_repo/commands/_common.py
+++ b/gh_safe_repo/commands/_common.py
@@ -231,17 +231,26 @@ def format_plan_json(plan):
     )
 
 
-def print_success(owner, repo):
+def print_success(owner, repo, local_push=False):
     url = f"https://github.com/{owner}/{repo}"
     https_url = f"https://github.com/{owner}/{repo}.git"
     ssh_url = f"git@github.com:{owner}/{repo}.git"
-    inner = (
-        f"  Repository created successfully!  \n"
-        f"  {url}  \n"
-        f"  \n"
-        f"  HTTPS: git remote add origin {https_url}  \n"
-        f"  SSH:   git remote add origin {ssh_url}  "
-    )
+    if local_push:
+        inner = (
+            f"  Repository created successfully!  \n"
+            f"  {url}  \n"
+            f"  \n"
+            f"  Set your tracking branch:  \n"
+            f"  git branch --set-upstream-to=origin/<branch> <branch>  "
+        )
+    else:
+        inner = (
+            f"  Repository created successfully!  \n"
+            f"  {url}  \n"
+            f"  \n"
+            f"  HTTPS: git remote add origin {https_url}  \n"
+            f"  SSH:   git remote add origin {ssh_url}  "
+        )
     width = max(len(line) for line in inner.splitlines()) + 2
     top    = "╭─ Done " + "─" * (width - 7) + "╮"
     bottom = "╰" + "─" * (width + 1) + "╯"

--- a/gh_safe_repo/commands/create.py
+++ b/gh_safe_repo/commands/create.py
@@ -367,4 +367,4 @@ def run(args):
     except APIError as e:
         warn(f"Tag protection failed: {e}")
 
-    print_success(owner, repo_name)
+    print_success(owner, repo_name, local_push=bool(args.local_path))


### PR DESCRIPTION
## Summary

- After `create --local`, the remote already exists — `git remote add origin` is wrong and errors immediately
- For `--local` creates, the success box now shows `git branch --set-upstream-to=origin/<branch> <branch>` instead
- Plain `create` (no code push) still shows `git remote add origin` as before

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/e2e` — 491 pass
- [ ] Manual: run `create <repo> --local .`, confirm success box shows the set-upstream hint
- [ ] Manual: run `create <repo>` (no --local), confirm success box still shows `git remote add origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)