### PR TITLE
Add clone instructions to repo create success message

### DIFF
--- a/gh_safe_repo/commands/_common.py
+++ b/gh_safe_repo/commands/_common.py
@@ -248,8 +248,13 @@ def print_success(owner, repo, local_push=False):
             f"  Repository created successfully!  \n"
             f"  {url}  \n"
             f"  \n"
+            f"  Add remote to existing repo:  \n"
             f"  HTTPS: git remote add origin {https_url}  \n"
-            f"  SSH:   git remote add origin {ssh_url}  "
+            f"  SSH:   git remote add origin {ssh_url}  \n"
+            f"  \n"
+            f"  Clone fresh:  \n"
+            f"  HTTPS: git clone {https_url}  \n"
+            f"  SSH:   git clone {ssh_url}  "
         )
     width = max(len(line) for line in inner.splitlines()) + 2
     top    = "╭─ Done " + "─" * (width - 7) + "╮"


### PR DESCRIPTION
## Summary
- Adds a "Clone fresh" section below "Add remote to existing repo" in the post-create success box
- Both sections show HTTPS and SSH variants
- Box auto-sizes to fit the new content

## Test plan
- [ ] `uv run pytest tests/ -v` passes (521 passed, 7 skipped)
- [ ] Visual: `print_success('owner', 'repo')` renders both sections with correct alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)