### PR TITLE
Make has_wiki, has_issues, has_projects opt-in

### DIFF
--- a/gh-safe-repo.ini.example
+++ b/gh-safe-repo.ini.example
@@ -7,13 +7,6 @@
 # Whether new repos are private by default
 private = true
 
-# Disable features that create clutter if unused
-has_wiki = false
-has_projects = false
-
-# Issues are usually wanted
-has_issues = true
-
 # Auto-delete head branches after merge (GitHub default: off)
 # Set to true if you want automatic cleanup after merging PRs
 delete_branch_on_merge = false

--- a/gh_safe_repo/config_manager.py
+++ b/gh_safe_repo/config_manager.py
@@ -19,9 +19,6 @@ CONFIG_FILENAME = "gh-safe-repo.ini"
 SAFE_DEFAULTS = {
     "repo": {
         "private": "true",
-        "has_wiki": "false",
-        "has_projects": "false",
-        "has_issues": "true",
         "delete_branch_on_merge": "false",
         "allow_squash_merge": "true",
         "allow_merge_commit": "true",

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -14,12 +14,6 @@ class TestConfigManagerDefaults:
         # Use a non-existent path so only defaults are loaded
         self.config = ConfigManager(config_path="/tmp/nonexistent-gh-safe-repo.ini")
 
-    def test_has_wiki_default_false(self):
-        assert self.config.getbool("repo", "has_wiki") is False
-
-    def test_has_projects_default_false(self):
-        assert self.config.getbool("repo", "has_projects") is False
-
     def test_delete_branch_on_merge_default_false(self):
         assert self.config.getbool("repo", "delete_branch_on_merge") is False
 
@@ -36,9 +30,9 @@ class TestConfigManagerDefaults:
 class TestConfigManagerOverrides:
     def test_apply_overrides_bool(self):
         config = ConfigManager(config_path="/tmp/nonexistent-gh-safe-repo.ini")
-        assert config.getbool("repo", "has_wiki") is False
-        config.apply_overrides({("repo", "has_wiki"): "true"})
-        assert config.getbool("repo", "has_wiki") is True
+        assert config.getbool("repo", "delete_branch_on_merge") is False
+        config.apply_overrides({("repo", "delete_branch_on_merge"): "true"})
+        assert config.getbool("repo", "delete_branch_on_merge") is True
 
     def test_apply_overrides_string(self):
         config = ConfigManager(config_path="/tmp/nonexistent-gh-safe-repo.ini")
@@ -59,8 +53,6 @@ class TestConfigManagerFileLoading:
         config = ConfigManager(config_path=path)
         assert config.getbool("repo", "has_wiki") is True
         assert config.getbool("repo", "delete_branch_on_merge") is True
-        # Other defaults remain
-        assert config.getbool("repo", "has_projects") is False
 
     def test_invalid_config_raises(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
@@ -78,7 +70,7 @@ class TestConfigManagerSettings:
     def test_repo_settings_returns_dict(self):
         settings = self.config.repo_settings()
         assert isinstance(settings, dict)
-        assert "has_wiki" in settings
+        assert "delete_branch_on_merge" in settings
 
     def test_actions_settings_returns_dict(self):
         settings = self.config.actions_settings()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -37,10 +37,16 @@ class TestRepositoryPlugin:
         adds = [c for c in plan.changes if c.type == ChangeType.ADD]
         assert any(c.key == "repository" for c in adds)
 
-    def test_plan_includes_update_for_has_wiki(self):
+    def test_plan_does_not_manage_has_wiki_by_default(self):
         client = make_mock_client()
-        # Default is has_wiki=false, GitHub default is true → should be UPDATE
         plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        plan = plugin.plan()
+        assert not any(c.key == "has_wiki" for c in plan.changes)
+
+    def test_plan_manages_has_wiki_when_opted_in(self):
+        client = make_mock_client()
+        plugin = RepositoryPlugin(client, "alice", "my-repo",
+                                  make_config({("repo", "has_wiki"): "false"}))
         plan = plugin.plan()
         updates = [c for c in plan.changes if c.type == ChangeType.UPDATE]
         wiki_change = next((c for c in updates if c.key == "has_wiki"), None)
@@ -71,10 +77,10 @@ class TestRepositoryPlugin:
     def test_apply_patches_settings(self):
         client = make_mock_client()
         client.call_json.return_value = {}
-        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        config = make_config({("repo", "has_wiki"): "false"})
+        plugin = RepositoryPlugin(client, "alice", "my-repo", config)
         plan = plugin.plan()
         plugin.apply(plan)
-        # Should have a PATCH call
         patch_calls = [
             c for c in client.call_json.call_args_list if c.args[0] == "PATCH"
         ]
@@ -166,7 +172,8 @@ class TestRepositoryPlugin:
             APIError("Not Found", status_code=404),  # PATCH attempt 1
             {},                                      # PATCH attempt 2
         ]
-        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        config = make_config({("repo", "has_wiki"): "false"})
+        plugin = RepositoryPlugin(client, "alice", "my-repo", config)
         plan = plugin.plan()
         plugin.apply(plan)
         patch_calls = [c for c in client.call_json.call_args_list if c.args[0] == "PATCH"]
@@ -184,7 +191,8 @@ class TestRepositoryPlugin:
             APIError("Not Found", status_code=404),
             APIError("Not Found", status_code=404),
         ]
-        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        config = make_config({("repo", "has_wiki"): "false"})
+        plugin = RepositoryPlugin(client, "alice", "my-repo", config)
         plan = plugin.plan()
         with pytest.raises(APIError):
             plugin.apply(plan)
@@ -781,7 +789,6 @@ class TestRepositoryPluginAudit:
         plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
         state = plugin.fetch_current_state()
         client.get_repo_data.assert_called_once_with("alice", "my-repo")
-        assert state["has_wiki"] is False
         assert state["delete_branch_on_merge"] is True
 
     def test_plan_audit_no_create_entry(self):
@@ -803,33 +810,28 @@ class TestRepositoryPluginAudit:
 
     def test_plan_audit_emits_update_for_diff(self):
         client = make_mock_client()
-        # has_wiki differs: current=True, desired=False
+        # allow_merge_commit differs: current=True, desired=True (default) — use
+        # allow_rebase_merge which differs from safe default (True vs True is same,
+        # so use allow_merge_commit=True desired vs current=False to force UPDATE)
         current_state = {
             "private": True,
-            "has_wiki": True,
-            "has_issues": True,
-            "has_projects": False,
             "delete_branch_on_merge": False,
             "allow_squash_merge": True,
-            "allow_merge_commit": True,
+            "allow_merge_commit": False,  # differs from safe default (true)
             "allow_rebase_merge": True,
         }
         plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
         plan = plugin.plan(current_state=current_state)
         updates = [c for c in plan.changes if c.type == ChangeType.UPDATE]
-        wiki_change = next((c for c in updates if c.key == "has_wiki"), None)
-        assert wiki_change is not None
-        assert wiki_change.old is True
-        assert wiki_change.new is False
+        change = next((c for c in updates if c.key == "allow_merge_commit"), None)
+        assert change is not None
+        assert change.old is False
+        assert change.new is True
 
     def test_plan_audit_emits_skip_for_match(self):
         client = make_mock_client()
-        # has_wiki already False (matches desired)
         current_state = {
             "private": True,
-            "has_wiki": False,
-            "has_issues": True,
-            "has_projects": False,
             "delete_branch_on_merge": False,
             "allow_squash_merge": True,
             "allow_merge_commit": True,
@@ -838,8 +840,8 @@ class TestRepositoryPluginAudit:
         plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
         plan = plugin.plan(current_state=current_state)
         skips = [c for c in plan.changes if c.type == ChangeType.SKIP]
-        assert any(c.key == "has_wiki" for c in skips)
-        skip = next(c for c in skips if c.key == "has_wiki")
+        assert any(c.key == "allow_merge_commit" for c in skips)
+        skip = next(c for c in skips if c.key == "allow_merge_commit")
         assert skip.reason == "Already at desired value"
 
     def test_apply_audit_skips_post(self):
@@ -848,12 +850,9 @@ class TestRepositoryPluginAudit:
         # In audit mode plan has no CREATE entry → POST should be skipped
         current_state = {
             "private": True,
-            "has_wiki": True,  # differs → UPDATE
-            "has_issues": True,
-            "has_projects": False,
             "delete_branch_on_merge": False,
             "allow_squash_merge": True,
-            "allow_merge_commit": True,
+            "allow_merge_commit": False,  # differs → UPDATE
             "allow_rebase_merge": True,
         }
         plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())


### PR DESCRIPTION
## Summary

- Remove \`has_wiki\`, \`has_issues\`, and \`has_projects\` from \`SAFE_DEFAULTS\` — they are no longer managed unless the user explicitly sets them in their config file
- These are user-preference settings, not security posture; the tool was silently marking repos out of compliance on every run and overriding whatever the user had chosen in GitHub
- The fields remain valid config keys (still in \`PATCH_FIELDS\`) — opt in by adding e.g. \`has_wiki = false\` to \`gh-safe-repo.ini\`

## Test plan

- [x] `uv run pytest tests/ -v` passes (512 passed, 7 skipped)
- [ ] `test_plan_does_not_manage_has_wiki_by_default` — confirms no plan entry without opt-in
- [ ] `test_plan_manages_has_wiki_when_opted_in` — confirms opt-in via config still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)