### PR TITLE
Default branch protection to Rulesets API, fix read/upsert path (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file was introduced with 0.2.0; the 0.2.0 entry backfills notable changes
 since the initial release.
 
+## [0.3.0] - 2026-06-12
+
+### Changed
+- Branch protection now uses the **Rulesets API by default** (`use_rulesets =
+  true`). A single `gh-safe-repo defaults` ruleset covers all configured branches
+  and expresses admin bypass via a bypass actor. The classic per-branch path is
+  kept for one release cycle behind `use_rulesets = false`. (#43)
+
+### Fixed
+- Rulesets read path: `fix`/`scan` now read existing branch rulesets via
+  `GET /repos/{owner}/{repo}/rulesets` instead of always reading the classic
+  endpoint, so a ruleset-configured repo no longer shows a false "all settings
+  missing" diff. (#43)
+- Idempotent upsert: `apply()` now `PATCH`es an existing `gh-safe-repo defaults`
+  ruleset instead of always `POST`ing, so re-running no longer creates duplicate
+  rulesets. (#43)
+
+### Added
+- `fix --migrate-branch-protection`: required to convert a repo that still has
+  classic branch protection over to a ruleset. Without it, `fix` reports the
+  classic protection and skips rather than silently dropping classic-only rules
+  (`required_status_checks`, push `restrictions`). With it, the ruleset is created
+  and the classic protection is deleted. (#43)
+
 ## [0.2.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ Fixing all of this manually takes minutes per repo and is easy to forget. `gh-sa
 | Allow branch deletion | No |
 | Enforce on admins | No (allows owner tooling to push) |
 
+Branch protection is applied via the **Rulesets API** by default (`use_rulesets =
+true`): a single `gh-safe-repo defaults` ruleset covers every configured branch
+and expresses "admins can bypass" through a bypass actor rather than the classic
+`enforce_admins` flag. Set `use_rulesets = false` for the legacy classic
+per-branch path (kept for one release cycle).
+
+**Migrating an existing repo from classic protection:** if `fix` finds classic
+branch protection on a repo, it refuses to convert it to a ruleset unless you pass
+`--migrate-branch-protection`. Classic-only rules have no equivalent in the ruleset
+this tool builds and would be dropped silently otherwise — known gaps:
+
+- `required_status_checks` — required CI checks are not modelled in the ruleset body.
+- `restrictions` (push restrictions by user/team) — Rulesets model this differently via bypass actors; not a 1:1 map.
+- Per-branch divergence — a single shared-condition ruleset can't express different rules for `master` vs `main`.
+
+With the flag, `fix` creates/updates the ruleset and then deletes the classic
+protection on each branch so the two layers don't stack.
+
 ### Tag protection (public repos, or any repo on a paid plan)
 
 Tag protection creates a GitHub Ruleset targeting all tags (`*` by default, configurable via `protected_tags`). The following rules are enforced:
@@ -624,9 +642,11 @@ allow_force_pushes = false
 # Block branch deletion
 allow_deletions = false
 
-# Use the Rulesets API instead of classic branch protection
-# Same rules, but supports bypass actors and is the modern GitHub API
-# use_rulesets = false
+# Use the Rulesets API (default) instead of the legacy classic branch-protection
+# path. A single ruleset covers all configured branches, supports bypass actors,
+# and is GitHub's forward direction (new rule types are Rulesets-only). Set false
+# to fall back to the classic per-branch API, which is kept for one release cycle.
+use_rulesets = true
 
 
 [tag_protection]
@@ -746,7 +766,7 @@ gh-safe-repo create <owner/repo>
       ├─ Build plan (each plugin compares desired vs. current state)
       │   ├─ RepositoryPlugin  → repo creation + basic settings
       │   ├─ ActionsPlugin     → allowed actions, workflow permissions, SHA pinning
-      │   ├─ BranchProtectionPlugin → classic or Rulesets API
+      │   ├─ BranchProtectionPlugin → Rulesets API (default; classic if use_rulesets = false)
       │   ├─ SecurityPlugin    → Dependabot, secret scanning, push protection, private vuln reporting
       │   └─ TagProtectionPlugin → immutable tags via Rulesets API
       │
@@ -756,8 +776,8 @@ gh-safe-repo create <owner/repo>
           ├─ POST /user/repos
           ├─ PATCH /repos/{owner}/{repo}       (settings)
           ├─ PUT  /repos/{owner}/{repo}/actions/permissions/workflow
-          ├─ PUT  /repos/{owner}/{repo}/branches/main/protection
-          │   or POST /repos/{owner}/{repo}/rulesets (if use_rulesets = true)
+          ├─ POST/PATCH /repos/{owner}/{repo}/rulesets  (branch protection; default)
+          │   or PUT /repos/{owner}/{repo}/branches/main/protection (if use_rulesets = false)
           ├─ PUT  /repos/{owner}/{repo}/vulnerability-alerts
           ├─ PUT  /repos/{owner}/{repo}/automated-security-fixes
           ├─ PUT  /repos/{owner}/{repo}/private-vulnerability-reporting

--- a/gh-safe-repo.ini.example
+++ b/gh-safe-repo.ini.example
@@ -80,8 +80,12 @@ allow_force_pushes = false
 # Block deletion of the protected branch
 allow_deletions = false
 
-# Use the Rulesets API instead of classic branch protection (same rules, adds bypass actors)
-use_rulesets = false
+# Use the Rulesets API (default) instead of the legacy classic branch-protection
+# path. Rulesets cover all branches in one object, support bypass actors, and are
+# GitHub's forward direction. Set false to use the classic per-branch API (kept
+# for one release cycle). Migrating a repo with existing classic protection
+# requires `fix --migrate-branch-protection`.
+use_rulesets = true
 
 [tag_protection]
 # Immutable tags via Rulesets API.

--- a/gh_safe_repo/README.md
+++ b/gh_safe_repo/README.md
@@ -33,7 +33,7 @@ gh_safe_repo/         ← this package (all real logic lives here)
 | `plugins/base.py` | Abstract `BasePlugin` — defines the `plan()` / `apply()` interface |
 | `plugins/repository.py` | Repo creation (`POST /user/repos`) and basic repo settings (`PATCH`) |
 | `plugins/actions.py` | GitHub Actions permissions (allowed actions, workflow perms, SHA pinning) |
-| `plugins/branch_protection.py` | Classic branch protection + Rulesets API |
+| `plugins/branch_protection.py` | Branch protection via Rulesets API (default; classic per-branch path behind `use_rulesets = false`) |
 | `plugins/security.py` | Dependabot alerts/security updates, secret scanning/push protection, private vuln reporting |
 | `plugins/tag_protection.py` | Immutable tags via Rulesets API (prevent deletion/rewriting of release tags) |
 | `templates/` | File templates (currently empty) |

--- a/gh_safe_repo/commands/fix.py
+++ b/gh_safe_repo/commands/fix.py
@@ -46,6 +46,16 @@ def add_arguments(parser):
         action="store_true",
         help="Show settings diff without applying changes",
     )
+    parser.add_argument(
+        "--migrate-branch-protection",
+        action="store_true",
+        help=(
+            "Migrate an existing classic branch protection to a ruleset. "
+            "Classic-only rules (required_status_checks, push restrictions) have "
+            "no ruleset equivalent and will be dropped; the classic protection is "
+            "deleted once the ruleset is in place."
+        ),
+    )
     add_common_args(parser)
 
 
@@ -117,6 +127,7 @@ def run(args):
             client, owner, repo_name, config,
             is_public=is_public, is_paid_plan=is_paid_plan,
             branches=audit_branches,
+            migrate=args.migrate_branch_protection,
         ),
         SecurityPlugin(
             client, owner, repo_name, config,

--- a/gh_safe_repo/config_manager.py
+++ b/gh_safe_repo/config_manager.py
@@ -45,7 +45,9 @@ SAFE_DEFAULTS = {
         "enforce_admins": "false",
         "allow_force_pushes": "false",
         "allow_deletions": "false",
-        "use_rulesets": "false",
+        # Rulesets API is the default; set false for the legacy classic
+        # branch-protection path (kept for one release cycle).
+        "use_rulesets": "true",
     },
     "tag_protection": {
         "protected_tags": "*",

--- a/gh_safe_repo/plugins/branch_protection.py
+++ b/gh_safe_repo/plugins/branch_protection.py
@@ -3,7 +3,17 @@ Branch protection plugin — applies classic branch protection or Rulesets API.
 
 Free plan: available for public repos only.
 Paid plan (Pro/Team): available for private repos too.
-Rulesets: opt-in via use_rulesets = true in config.
+
+Rulesets are the default (use_rulesets = true). A single ruleset covers all
+configured branches via conditions.ref_name.include, supports bypass actors,
+and is GitHub's forward direction (new rule types are Rulesets-only). The
+classic per-branch protection path is kept for one release cycle via
+use_rulesets = false.
+
+Migrating a repo that already has classic protection requires the explicit
+--migrate-branch-protection flag: classic rules like required_status_checks and
+push restrictions have no ruleset equivalent here and would be dropped, so the
+migration is never silent.
 """
 
 import json
@@ -24,15 +34,50 @@ GITHUB_DEFAULTS = {
     "allow_deletions": True,
 }
 
+RULESET_NAME = "gh-safe-repo defaults"
+
 
 class BranchProtectionPlugin(BasePlugin):
-    def __init__(self, client, owner, repo, config, is_public=False, is_paid_plan=False, branches=None):
+    def __init__(self, client, owner, repo, config, is_public=False, is_paid_plan=False,
+                 branches=None, migrate=False):
         super().__init__(client, owner, repo, config)
         self.is_public = is_public
         self.is_paid_plan = is_paid_plan
         self.branches = branches or ["master", "main"]
+        self.migrate = migrate
+        # Set during fetch_current_state() in rulesets mode; gates migration.
+        self._classic_present = False
+
+    def _use_rulesets(self) -> bool:
+        return self.config.getbool("branch_protection", "use_rulesets", fallback=True)
+
+    # ── State reads ───────────────────────────────────────────────────────────
 
     def fetch_current_state(self) -> dict:
+        if self._use_rulesets():
+            # Record any pre-existing classic protection so plan() can gate the
+            # migration behind --migrate-branch-protection.
+            self._classic_present = self._classic_protection_present()
+            return self._fetch_ruleset_state()
+        return self._fetch_classic_state()
+
+    def _classic_protection_present(self) -> bool:
+        """True if any configured branch has classic protection configured.
+
+        The classic endpoint 404s when no protection is set, so a 200 means
+        classic rules exist. 403 (free+private) is treated as absent — plan()
+        SKIPs on plan-availability grounds in that case anyway.
+        """
+        for branch in self.branches:
+            path = self.client.repo_path(
+                self.owner, self.repo, f"branches/{branch}/protection"
+            )
+            status, _ = self.client.call_api("GET", path)
+            if status == 200:
+                return True
+        return False
+
+    def _fetch_classic_state(self) -> dict:
         branch = self.branches[0]
         path = self.client.repo_path(self.owner, self.repo, f"branches/{branch}/protection")
         status, text = self.client.call_api("GET", path)
@@ -86,6 +131,87 @@ class BranchProtectionPlugin(BasePlugin):
 
         return result
 
+    def _fetch_ruleset_state(self) -> dict:
+        """Read the gh-safe-repo branch ruleset and map it to the canonical dict.
+
+        Inverse of _build_ruleset_body(). Falls back to permissive GITHUB_DEFAULTS
+        when no matching ruleset exists, or when rulesets are inaccessible
+        (404/403 on free+private).
+        """
+        detail = self._fetch_ruleset_detail()
+        if detail is None:
+            return dict(GITHUB_DEFAULTS)
+
+        rules = detail.get("rules", [])
+        rule_by_type = {r.get("type"): r for r in rules}
+
+        result = {
+            "allow_force_pushes": "non_fast_forward" not in rule_by_type,
+            "allow_deletions": "deletion" not in rule_by_type,
+        }
+
+        pr = rule_by_type.get("pull_request")
+        if pr is not None:
+            params = pr.get("parameters", {})
+            result["require_pull_request"] = True
+            result["required_approving_reviews"] = params.get(
+                "required_approving_review_count", 0
+            )
+            result["dismiss_stale_reviews"] = params.get(
+                "dismiss_stale_reviews_on_push", False
+            )
+            result["require_conversation_resolution"] = params.get(
+                "required_review_thread_resolution", False
+            )
+        else:
+            result["require_pull_request"] = False
+            result["required_approving_reviews"] = 0
+            result["dismiss_stale_reviews"] = False
+            result["require_conversation_resolution"] = False
+
+        # enforce_admins=False is expressed as a RepositoryRole(Admin, id=5) bypass.
+        bypass = detail.get("bypass_actors", [])
+        admin_bypass = any(
+            a.get("actor_type") == "RepositoryRole" and a.get("actor_id") == 5
+            for a in bypass
+        )
+        result["enforce_admins"] = not admin_bypass
+
+        return result
+
+    def _fetch_ruleset_detail(self) -> dict | None:
+        """Return the full detail of our branch ruleset, or None if absent."""
+        ruleset_id = self._find_ruleset_id()
+        if ruleset_id is None:
+            return None
+        detail_path = self.client.repo_path(self.owner, self.repo, f"rulesets/{ruleset_id}")
+        status, text = self.client.call_api("GET", detail_path)
+        if status and status >= 400:
+            return None
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    def _find_ruleset_id(self):
+        """Return the id of our branch ruleset, or None if it doesn't exist."""
+        path = self.client.repo_path(self.owner, self.repo, "rulesets")
+        status, text = self.client.call_api("GET", path)
+        if status == 404 or status == 403:
+            return None
+        if status and status >= 400:
+            raise APIError(f"GET {path} returned {status}", status_code=status)
+        try:
+            rulesets = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            raise APIError(f"GET {path} returned non-JSON response")
+        for rs in rulesets:
+            if rs.get("target") == "branch" and rs.get("name") == RULESET_NAME:
+                return rs.get("id")
+        return None
+
+    # ── Plan ────────────────────────────────────────────────────────────────
+
     def plan(self, current_state=None) -> Plan:
         plan = Plan()
 
@@ -95,6 +221,21 @@ class BranchProtectionPlugin(BasePlugin):
                 category=ChangeCategory.BRANCH_PROTECTION,
                 key="branch_protection",
                 reason="Branch protection requires a public repo or paid GitHub plan",
+            ))
+            return plan
+
+        # Migration gate: never silently convert classic protection to a ruleset.
+        if self._use_rulesets() and self._classic_present and not self.migrate:
+            plan.add(Change(
+                type=ChangeType.SKIP,
+                category=ChangeCategory.BRANCH_PROTECTION,
+                key="branch_protection",
+                reason=(
+                    "Existing classic branch protection detected. Re-run with "
+                    "--migrate-branch-protection to migrate it to a ruleset "
+                    "(classic-only rules such as required_status_checks and push "
+                    "restrictions have no ruleset equivalent and will be dropped)."
+                ),
             ))
             return plan
 
@@ -133,6 +274,8 @@ class BranchProtectionPlugin(BasePlugin):
 
         return plan
 
+    # ── Apply ─────────────────────────────────────────────────────────────────
+
     def apply(self, plan: Plan) -> None:
         bp_changes = [
             c for c in plan.actionable_changes
@@ -141,39 +284,63 @@ class BranchProtectionPlugin(BasePlugin):
         if not bp_changes:
             return
 
-        use_rulesets = self.config.getbool("branch_protection", "use_rulesets", fallback=False)
         desired = self._desired()
 
-        if use_rulesets:
-            body = self._build_ruleset_body(desired)
+        if self._use_rulesets():
+            self._apply_ruleset(desired)
+        else:
+            self._apply_classic(desired)
+
+    def _apply_ruleset(self, desired: dict) -> None:
+        body = self._build_ruleset_body(desired)
+        existing_id = self._find_ruleset_id()
+        if existing_id is not None:
+            path = self.client.repo_path(self.owner, self.repo, f"rulesets/{existing_id}")
+            self.client.call_json("PATCH", path, body)
+        else:
             path = self.client.repo_path(self.owner, self.repo, "rulesets")
             self.client.call_json("POST", path, body)
-        else:
-            body = {
-                "required_status_checks": None,
-                "enforce_admins": desired["enforce_admins"],
-                "required_pull_request_reviews": {
-                    "dismiss_stale_reviews": desired["dismiss_stale_reviews"],
-                    "require_code_owner_reviews": False,
-                    "required_approving_review_count": desired["required_approving_reviews"],
-                },
-                "restrictions": None,
-                "allow_force_pushes": desired["allow_force_pushes"],
-                "allow_deletions": desired["allow_deletions"],
-                "required_conversation_resolution": desired["require_conversation_resolution"],
-            }
+
+        # Migration: remove the classic protection now that the ruleset is in place.
+        # Gated by plan() — we only reach here with migrate=True when classic exists.
+        if self.migrate and self._classic_present:
             for branch in self.branches:
-                path = self.client.repo_path(self.owner, self.repo, f"branches/{branch}/protection")
+                del_path = self.client.repo_path(
+                    self.owner, self.repo, f"branches/{branch}/protection"
+                )
                 try:
-                    self.client.call_json("PUT", path, body)
+                    self.client.call_json("DELETE", del_path)
                 except APIError as e:
                     if e.status_code in (404, 422):
-                        print(
-                            f"[skip] Branch '{branch}' not found — skipping protection",
-                            file=sys.stderr,
-                        )
                         continue
                     raise
+
+    def _apply_classic(self, desired: dict) -> None:
+        body = {
+            "required_status_checks": None,
+            "enforce_admins": desired["enforce_admins"],
+            "required_pull_request_reviews": {
+                "dismiss_stale_reviews": desired["dismiss_stale_reviews"],
+                "require_code_owner_reviews": False,
+                "required_approving_review_count": desired["required_approving_reviews"],
+            },
+            "restrictions": None,
+            "allow_force_pushes": desired["allow_force_pushes"],
+            "allow_deletions": desired["allow_deletions"],
+            "required_conversation_resolution": desired["require_conversation_resolution"],
+        }
+        for branch in self.branches:
+            path = self.client.repo_path(self.owner, self.repo, f"branches/{branch}/protection")
+            try:
+                self.client.call_json("PUT", path, body)
+            except APIError as e:
+                if e.status_code in (404, 422):
+                    print(
+                        f"[skip] Branch '{branch}' not found — skipping protection",
+                        file=sys.stderr,
+                    )
+                    continue
+                raise
 
     def _build_ruleset_body(self, desired: dict) -> dict:
         rules = []
@@ -201,7 +368,7 @@ class BranchProtectionPlugin(BasePlugin):
                 "bypass_mode": "always",
             })
         return {
-            "name": "gh-safe-repo defaults",
+            "name": RULESET_NAME,
             "target": "branch",
             "enforcement": "active",
             "conditions": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gh-safe-repo"
-version = "0.2.0"
+version = "0.3.0"
 description = "Create GitHub repositories with safe defaults applied"
 requires-python = ">=3.10"
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -406,7 +406,8 @@ class TestBranchProtectionPlugin:
     def test_apply_public_repo_puts_branch_protection(self):
         client = make_mock_client()
         client.call_json.return_value = {}
-        plugin = BranchProtectionPlugin(client, "alice", "my-repo", make_config(), is_public=True)
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
+        plugin = BranchProtectionPlugin(client, "alice", "my-repo", config, is_public=True)
         plan = plugin.plan()
         plugin.apply(plan)
         assert client.call_json.called
@@ -417,7 +418,8 @@ class TestBranchProtectionPlugin:
     def test_apply_public_repo_body_has_correct_fields(self):
         client = make_mock_client()
         client.call_json.return_value = {}
-        plugin = BranchProtectionPlugin(client, "alice", "my-repo", make_config(), is_public=True)
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
+        plugin = BranchProtectionPlugin(client, "alice", "my-repo", config, is_public=True)
         plan = plugin.plan()
         plugin.apply(plan)
         body = client.call_json.call_args.args[2]
@@ -430,7 +432,8 @@ class TestBranchProtectionPlugin:
     def test_apply_public_repo_uses_explicit_branches(self):
         client = make_mock_client()
         client.call_json.return_value = {}
-        plugin = BranchProtectionPlugin(client, "alice", "my-repo", make_config(), is_public=True, branches=["master"])
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
+        plugin = BranchProtectionPlugin(client, "alice", "my-repo", config, is_public=True, branches=["master"])
         plan = plugin.plan()
         plugin.apply(plan)
         assert "branches/master/protection" in client.call_json.call_args.args[1]
@@ -438,8 +441,9 @@ class TestBranchProtectionPlugin:
     def test_apply_multi_branch_calls_put_for_each(self):
         client = make_mock_client()
         client.call_json.return_value = {}
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
         plugin = BranchProtectionPlugin(
-            client, "alice", "my-repo", make_config(), is_public=True, branches=["master", "main"]
+            client, "alice", "my-repo", config, is_public=True, branches=["master", "main"]
         )
         plan = plugin.plan()
         plugin.apply(plan)
@@ -457,8 +461,9 @@ class TestBranchProtectionPlugin:
                 raise _APIError("not found", status_code=404)
             return {}
         client.call_json.side_effect = side_effect
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
         plugin = BranchProtectionPlugin(
-            client, "alice", "my-repo", make_config(), is_public=True, branches=["master", "main"]
+            client, "alice", "my-repo", config, is_public=True, branches=["master", "main"]
         )
         plan = plugin.plan()
         plugin.apply(plan)  # should not raise
@@ -500,22 +505,49 @@ class TestBranchProtectionPlugin:
 
     # --- Rulesets API ---
 
-    def test_apply_uses_rulesets_endpoint_when_configured(self):
+    def test_apply_rulesets_is_default(self):
         client = make_mock_client()
+        client.call_api.return_value = (200, "[]")  # no existing ruleset
+        client.call_json.return_value = {}
+        plugin = BranchProtectionPlugin(client, "alice", "my-repo", make_config(), is_public=True)
+        plan = plugin.plan()
+        plugin.apply(plan)
+        call = client.call_json.call_args
+        assert call.args[0] == "POST"
+        assert call.args[1].endswith("/rulesets")
+
+    def test_apply_posts_new_ruleset_when_absent(self):
+        client = make_mock_client()
+        client.call_api.return_value = (200, "[]")  # no existing ruleset
         client.call_json.return_value = {}
         config = make_config({("branch_protection", "use_rulesets"): "true"})
         plugin = BranchProtectionPlugin(client, "alice", "my-repo", config, is_public=True)
         plan = plugin.plan()
         plugin.apply(plan)
-        assert client.call_json.called
         call = client.call_json.call_args
         assert call.args[0] == "POST"
         assert call.args[1].endswith("/rulesets")
 
-    def test_apply_uses_classic_endpoint_by_default(self):
+    def test_apply_patches_existing_ruleset(self):
         client = make_mock_client()
+        # Existing ruleset present → upsert should PATCH, not POST.
+        existing = json.dumps([
+            {"id": 99, "name": "gh-safe-repo defaults", "target": "branch"},
+        ])
+        client.call_api.return_value = (200, existing)
         client.call_json.return_value = {}
         plugin = BranchProtectionPlugin(client, "alice", "my-repo", make_config(), is_public=True)
+        plan = plugin.plan()
+        plugin.apply(plan)
+        call = client.call_json.call_args
+        assert call.args[0] == "PATCH"
+        assert call.args[1].endswith("/rulesets/99")
+
+    def test_apply_uses_classic_endpoint_when_disabled(self):
+        client = make_mock_client()
+        client.call_json.return_value = {}
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
+        plugin = BranchProtectionPlugin(client, "alice", "my-repo", config, is_public=True)
         plan = plugin.plan()
         plugin.apply(plan)
         assert client.call_json.called
@@ -1023,8 +1055,9 @@ class TestBranchProtectionPluginAudit:
             "required_conversation_resolution": {"enabled": True},
         }
         client.call_api.return_value = (200, _json.dumps(api_response))
+        config = make_config({("branch_protection", "use_rulesets"): "false"})
         plugin = BranchProtectionPlugin(
-            client, "alice", "my-repo", make_config(), is_public=True
+            client, "alice", "my-repo", config, is_public=True
         )
         state = plugin.fetch_current_state()
         assert state["require_pull_request"] is True
@@ -1090,6 +1123,125 @@ class TestBranchProtectionPluginAudit:
         )
         plan = plugin.plan(current_state=current_state)
         assert all(c.type == ChangeType.SKIP for c in plan.changes)
+
+
+class TestBranchProtectionRulesetAudit:
+    """Rulesets-mode read path (default) and idempotent upsert."""
+
+    def _ruleset_detail(self):
+        return json.dumps({
+            "id": 7,
+            "name": "gh-safe-repo defaults",
+            "target": "branch",
+            "rules": [
+                {"type": "non_fast_forward"},
+                {"type": "deletion"},
+                {"type": "pull_request", "parameters": {
+                    "required_approving_review_count": 1,
+                    "dismiss_stale_reviews_on_push": True,
+                    "required_review_thread_resolution": True,
+                }},
+            ],
+            "bypass_actors": [
+                {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
+            ],
+        })
+
+    def test_fetch_current_state_reads_ruleset(self):
+        client = make_mock_client()
+        ruleset_list = json.dumps([
+            {"id": 7, "name": "gh-safe-repo defaults", "target": "branch"},
+        ])
+        # 1) classic-present probe → 404 (none), 2) find ruleset list, 3) detail
+        client.call_api.side_effect = [
+            (404, ""),
+            (200, ruleset_list),
+            (200, self._ruleset_detail()),
+        ]
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True, branches=["main"],
+        )
+        state = plugin.fetch_current_state()
+        assert state["require_pull_request"] is True
+        assert state["required_approving_reviews"] == 1
+        assert state["dismiss_stale_reviews"] is True
+        assert state["require_conversation_resolution"] is True
+        assert state["allow_force_pushes"] is False
+        assert state["allow_deletions"] is False
+        assert state["enforce_admins"] is False  # admin bypass present
+
+    def test_fetch_current_state_no_ruleset_returns_defaults(self):
+        client = make_mock_client()
+        # classic probe → 404; ruleset list → empty
+        client.call_api.side_effect = [(404, ""), (200, "[]")]
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True, branches=["main"],
+        )
+        state = plugin.fetch_current_state()
+        assert state["require_pull_request"] is False
+        assert state["allow_force_pushes"] is True
+        assert state["allow_deletions"] is True
+
+    def test_fetch_current_state_enforce_admins_true_without_bypass(self):
+        client = make_mock_client()
+        ruleset_list = json.dumps([
+            {"id": 7, "name": "gh-safe-repo defaults", "target": "branch"},
+        ])
+        detail = json.dumps({
+            "id": 7, "name": "gh-safe-repo defaults", "target": "branch",
+            "rules": [{"type": "non_fast_forward"}],
+            "bypass_actors": [],
+        })
+        client.call_api.side_effect = [(404, ""), (200, ruleset_list), (200, detail)]
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True, branches=["main"],
+        )
+        state = plugin.fetch_current_state()
+        assert state["enforce_admins"] is True  # no bypass actor → admins enforced
+
+    def test_plan_gates_migration_when_classic_present(self):
+        client = make_mock_client()
+        # classic probe returns 200 (classic protection exists)
+        client.call_api.side_effect = [(200, "{}"), (200, "[]")]
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True,
+            branches=["main"], migrate=False,
+        )
+        state = plugin.fetch_current_state()
+        plan = plugin.plan(current_state=state)
+        # Single blocking SKIP, no actionable changes
+        assert len(plan.changes) == 1
+        skip = plan.changes[0]
+        assert skip.type == ChangeType.SKIP
+        assert "migrate-branch-protection" in skip.reason
+
+    def test_plan_proceeds_with_migrate_flag(self):
+        client = make_mock_client()
+        client.call_api.side_effect = [(200, "{}"), (200, "[]")]
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True,
+            branches=["main"], migrate=True,
+        )
+        state = plugin.fetch_current_state()
+        plan = plugin.plan(current_state=state)
+        assert any(c.type != ChangeType.SKIP for c in plan.changes)
+
+    def test_apply_migrate_deletes_classic_protection(self):
+        client = make_mock_client()
+        # fetch: classic probe → 200, ruleset list → empty
+        # apply: find ruleset → empty (POST), then DELETE classic
+        client.call_api.side_effect = [(200, "{}"), (200, "[]"), (200, "[]")]
+        client.call_json.return_value = {}
+        plugin = BranchProtectionPlugin(
+            client, "alice", "my-repo", make_config(), is_public=True,
+            branches=["main"], migrate=True,
+        )
+        state = plugin.fetch_current_state()
+        plan = plugin.plan(current_state=state)
+        plugin.apply(plan)
+        methods = [(c.args[0], c.args[1]) for c in client.call_json.call_args_list]
+        assert ("POST", "/repos/alice/my-repo/rulesets") in methods
+        assert any(m == "DELETE" and "branches/main/protection" in u for m, u in methods)
 
 
 class TestSecurityPluginAudit:

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "gh-safe-repo"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #43.

## What & why

The `use_rulesets = true` opt-in was half-implemented — the write path worked, but state reads and idempotency were broken:

- `fetch_current_state()` always read the **classic** endpoint, so a ruleset-configured repo showed a false "all settings missing" diff.
- `apply()` always `POST`ed, creating **duplicate rulesets** on every re-run.

This finishes the work and makes Rulesets the default, per GitHub's forward direction (new rule types are Rulesets-only).

## Changes

- **`fetch_current_state()`** dispatches on `use_rulesets`. New `_fetch_ruleset_state()` reads `GET /rulesets`, finds the `gh-safe-repo defaults` branch ruleset, fetches detail, and maps rules back to the canonical dict (inverse of `_build_ruleset_body`) — mirrors the working `tag_protection.py` pattern.
- **`apply()`** upserts: `PATCH` an existing ruleset, else `POST`.
- **Default flipped** to `use_rulesets = true`. Classic per-branch path kept one release cycle behind `use_rulesets = false`.
- **`fix --migrate-branch-protection`** gates conversion of repos that still have classic protection. Classic-only rules (`required_status_checks`, push `restrictions`, per-branch divergence) have no equivalent in the ruleset this tool builds, so without the flag `fix` reports and skips rather than dropping them silently. With the flag, the ruleset is created and the classic protection is deleted so the layers don't stack.
- Version bump to **0.3.0** + CHANGELOG; README / module README / `.ini.example` updated with the migration gaps.

## Design decisions (confirmed with maintainer)

- **Always require the flag** when classic protection exists — even when rules map cleanly — rather than auto-detecting clean vs. unclean migrations.
- **Flip the default in this same PR** (migration handling lands alongside it).

## Testing

`uv run pytest tests/ -v` — 543 passed, 7 skipped. New cases cover the ruleset read path, `enforce_admins` round-trip via bypass actor, POST-vs-PATCH upsert, the migration gate (skip without flag, proceed with), and classic deletion on migrate.

## Out of scope

`tag_protection.py:apply()` has the identical always-`POST` duplicate bug; the issue scoped it out. One-method follow-up using the same `_find_ruleset_id` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)