### PR TITLE
Require --local PATH to be a git repository (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file was introduced with 0.2.0; the 0.2.0 entry backfills notable changes
 since the initial release.
 
+## [0.4.0] - 2026-06-13
+
+### Changed
+- `create --local PATH` now requires `PATH` to be a git repository. Plain
+  directories (non-git) are rejected with a clear error message suggesting
+  `git init`. This ensures SSH transport discovery (via `core.sshCommand` /
+  `includeIf`) works correctly for multi-account setups. (#59)
+
 ## [0.3.0] - 2026-06-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ All commands that interact with GitHub require the `owner/repo` format (e.g. `my
 | Option | Description |
 |---|---|
 | `--public` | Create as a public repo (default: private) |
-| `--local PATH` | Push code from a local directory into the new repo. Runs pre-flight scan first. Mutually exclusive with `--from`. |
+| `--local PATH` | Push code from a local git repository into the new repo. Runs pre-flight scan first. Mutually exclusive with `--from`. |
 | `--from OWNER/REPO` | Mirror code from an existing repo into the new repo. Runs pre-flight scan. Mutually exclusive with `--local`. |
 | `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
 | `--dry-run` | Print the plan without making any changes |
@@ -368,7 +368,7 @@ If the scan reveals a problem and you abort, no code is ever copied to GitHub.
 
 ## Creating a Repo from a Local Directory (`--local`)
 
-`--local PATH` is the local-to-GitHub counterpart to `--from`. It creates a new GitHub repo and pushes code from a directory on your machine.
+`--local PATH` is the local-to-GitHub counterpart to `--from`. It creates a new GitHub repo and pushes code from a local git repository. `PATH` must be an initialized git repository (`git init` or a clone).
 
 ```bash
 gh-safe-repo create <owner/repo> --local ~/projects/myapp
@@ -381,16 +381,13 @@ gh-safe-repo create <owner/repo> --local ~/projects/myapp --public
 2. The [pre-flight security scanner](#pre-flight-security-scanner) runs on the local directory directly (no clone needed)
 3. You review findings and confirm (or abort)
 4. A new repo is created, and actions permissions and security settings are applied
-5. Code is pushed:
-   - If `PATH` is a git repo: the full history is cloned locally and pushed with `push --all --tags` (all branches and tags)
-   - If `PATH` is a plain directory: files are staged in a fresh repo and pushed as an initial commit
-   - If `PATH` is an empty directory: nothing is pushed (silently skipped)
+5. The full history is pushed with `push --all --tags` (all branches and tags)
 6. Branch and tag protection are applied (after code push, so the target branch exists)
-7. If `PATH` is a git repo, `origin` is added to the **original** local repo pointing at the new GitHub URL, and the current branch's upstream tracking is configured — so `git push` and `git pull` work immediately without extra setup.
+7. `origin` is added to the **original** local repo pointing at the new GitHub URL, and the current branch's upstream tracking is configured — so `git push` and `git pull` work immediately without extra setup.
 
 Both `--local` and `--from` work for private and public repos. They are mutually exclusive.
 
-When `PATH` is a git repo, the local default branch (via `git -C PATH symbolic-ref HEAD`) is used to target branch protection rules, so protection lands on the right branch even if it isn't `main`.
+The local default branch (via `git -C PATH symbolic-ref HEAD`) is used to target branch protection rules, so protection lands on the right branch even if it isn't `main`.
 
 > **Tip:** Run `gh-safe-repo scan PATH` first if you want to inspect findings without creating anything.
 

--- a/gh_safe_repo/commands/create.py
+++ b/gh_safe_repo/commands/create.py
@@ -53,7 +53,7 @@ def add_arguments(parser):
         "--local",
         dest="local_path",
         metavar="PATH",
-        help="Push code from a local directory into the new repo",
+        help="Push code from a local git repository into the new repo",
     )
     parser.add_argument(
         "--from",
@@ -151,6 +151,9 @@ def run(args):
         local_path = os.path.abspath(args.local_path)
         if not os.path.isdir(local_path):
             error(f"--local: '{args.local_path}' is not a directory")
+            sys.exit(2)
+        if not os.path.exists(os.path.join(local_path, ".git")):
+            error(f"--local: '{args.local_path}' is not a git repository (run 'git init' first)")
             sys.exit(2)
 
     # Validate source repo exists (--from workflow) and capture metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gh-safe-repo"
-version = "0.3.0"
+version = "0.4.0"
 description = "Create GitHub repositories with safe defaults applied"
 requires-python = ">=3.10"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,22 @@ class TestCreateFlagValidation:
                     main()
         assert exc_info.value.code == 2
 
+    def test_local_not_a_git_repo_exits_with_error(self, tmp_path, capsys):
+        """--local PATH must be a git repository; plain directories are rejected."""
+        with patch("sys.argv", [
+            "gh-safe-repo", "create", "alice/my-repo",
+            "--local", str(tmp_path), "--dry-run",
+        ]):
+            with patch("gh_safe_repo.commands.create.build_context") as mock_ctx:
+                mock_ctx.return_value = MagicMock(
+                    client=MagicMock(), owner="alice", plan_name="free",
+                    is_paid_plan=False, config=make_config(),
+                )
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+        assert exc_info.value.code == 2
+        assert "not a git repository" in capsys.readouterr().err
+
     def test_bare_repo_name_exits(self):
         """create my-repo (no owner/) should exit with error."""
         with patch("sys.argv", ["gh-safe-repo", "create", "my-repo"]):
@@ -230,6 +246,7 @@ class TestCreateFlagValidation:
 
     def test_credential_check_skipped_in_dry_run(self, tmp_path):
         """--dry-run makes zero external calls; credential probe is also skipped."""
+        (tmp_path / ".git").mkdir()
         mock_client = MagicMock()
         with patch("sys.argv", [
             "gh-safe-repo", "create", "alice/my-repo", "--local", str(tmp_path), "--dry-run",
@@ -252,6 +269,7 @@ class TestCreateFlagValidation:
         This was the actual bug — a typed lowercase owner produced a redirected
         push URL, which GitHub rejects for repos containing workflow files.
         """
+        (tmp_path / ".git").mkdir()
         mock_client = MagicMock()
         mock_client.check_repo_exists.return_value = False
         # Successful repo create response


### PR DESCRIPTION
## Summary

- `create --local PATH` now errors immediately if `PATH` has no `.git` directory, with a message suggesting `git init`
- Bumps version to 0.4.0 and updates CHANGELOG, README, and argparse help text

## Why

SSH transport discovery reads `core.sshCommand` via `includeIf "gitdir:..."`, which only fires when `source_dir` has a `.git` directory. When `--local` was pointed at a plain (non-git) directory, `core.sshCommand` was never found, `GIT_SSH_COMMAND` was not set, and the preflight fell back to the wrong SSH identity — producing "Permission denied (publickey)" even though `git clone` worked fine in the same shell session.

## Test plan

- [ ] `gh-safe-repo create owner/repo --local /tmp/plain-dir` → error: "not a git repository (run 'git init' first)", exits before any API call
- [ ] `gh-safe-repo create owner/repo --local /tmp/git-dir` (has `.git`) → proceeds normally
- [ ] `gh-safe-repo create owner/repo --local /nonexistent` → still catches "not a directory" first

🤖 Generated with [Claude Code](https://claude.com/claude-code)