### PR TITLE
Order success-banner remote suggestions by git protocol (#19)

### DIFF
--- a/gh_safe_repo/commands/_common.py
+++ b/gh_safe_repo/commands/_common.py
@@ -231,10 +231,15 @@ def format_plan_json(plan):
     )
 
 
-def print_success(owner, repo, local_push=False):
+def print_success(owner, repo, local_push=False, protocol="https"):
     url = f"https://github.com/{owner}/{repo}"
     https_url = f"https://github.com/{owner}/{repo}.git"
     ssh_url = f"git@github.com:{owner}/{repo}.git"
+    # Order remote suggestions by the user's preferred git protocol (#19),
+    # so the line they're most likely to use is listed first.
+    https = ("HTTPS", https_url)
+    ssh = ("SSH  ", ssh_url)
+    ordered = (ssh, https) if protocol == "ssh" else (https, ssh)
     if local_push:
         inner = (
             f"  Repository created successfully!  \n"
@@ -249,12 +254,12 @@ def print_success(owner, repo, local_push=False):
             f"  {url}  \n"
             f"  \n"
             f"  Add remote to existing repo:  \n"
-            f"  HTTPS: git remote add origin {https_url}  \n"
-            f"  SSH:   git remote add origin {ssh_url}  \n"
+            f"  {ordered[0][0]}: git remote add origin {ordered[0][1]}  \n"
+            f"  {ordered[1][0]}: git remote add origin {ordered[1][1]}  \n"
             f"  \n"
             f"  Clone fresh:  \n"
-            f"  HTTPS: git clone {https_url}  \n"
-            f"  SSH:   git clone {ssh_url}  "
+            f"  {ordered[0][0]}: git clone {ordered[0][1]}  \n"
+            f"  {ordered[1][0]}: git clone {ordered[1][1]}  "
         )
     width = max(len(line) for line in inner.splitlines()) + 2
     top    = "╭─ Done " + "─" * (width - 7) + "╮"

--- a/gh_safe_repo/commands/create.py
+++ b/gh_safe_repo/commands/create.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ..diff import Change, ChangeCategory, ChangeType, Plan
 from ..errors import APIError, AuthError, ConfigError, RepoExistsError, SafeRepoError
-from ..git_transport import discover_transport
+from ..git_transport import discover_transport, git_protocol_preference
 from ..plugins.actions import ActionsPlugin
 from ..plugins.branch_protection import BranchProtectionPlugin
 from ..plugins.repository import RepositoryPlugin
@@ -375,4 +375,11 @@ def run(args):
     except APIError as e:
         warn(f"Tag protection failed: {e}")
 
-    print_success(owner, repo_name, local_push=bool(args.local_path))
+    protocol = (
+        client.transport.protocol
+        if getattr(client, "transport", None) is not None
+        else git_protocol_preference()
+    )
+    print_success(
+        owner, repo_name, local_push=bool(args.local_path), protocol=protocol
+    )

--- a/gh_safe_repo/git_transport.py
+++ b/gh_safe_repo/git_transport.py
@@ -253,6 +253,15 @@ def _gh_get_protocol(host: str = "github.com") -> str:
     return "https"
 
 
+def git_protocol_preference(host: str = "github.com") -> str:
+    """Public: the user's preferred git protocol ("ssh" or "https").
+
+    Wraps the gh-config lookup so callers (e.g. the success banner) can order
+    remote suggestions by preference without constructing a full GitTransport.
+    """
+    return _gh_get_protocol(host)
+
+
 def _git_config_get(source_dir: str, key: str) -> Optional[str]:
     """Return `git -C source_dir config --get <key>` value, or None."""
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from gh_safe_repo.commands._common import (
     build_context,
     format_plan_json,
     parse_repo_arg,
+    print_success,
 )
 from gh_safe_repo.cli import main
 from gh_safe_repo.commands import create, fix, scan
@@ -677,3 +678,28 @@ class TestScanSkippedDirsWarning:
 
         captured = capsys.readouterr()
         assert "skipped during scan" not in captured.out
+
+
+class TestPrintSuccessProtocolOrdering:
+    """Success banner orders remote suggestions by the user's git protocol (#19)."""
+
+    def test_https_preference_lists_https_first(self, capsys):
+        print_success("octocat", "demo", protocol="https")
+        out = capsys.readouterr().out
+        assert out.index("HTTPS: git remote add") < out.index("SSH  : git remote add")
+
+    def test_ssh_preference_lists_ssh_first(self, capsys):
+        print_success("octocat", "demo", protocol="ssh")
+        out = capsys.readouterr().out
+        assert out.index("SSH  : git remote add") < out.index("HTTPS: git remote add")
+
+    def test_default_protocol_is_https_first(self, capsys):
+        print_success("octocat", "demo")
+        out = capsys.readouterr().out
+        assert out.index("HTTPS: git remote add") < out.index("SSH  : git remote add")
+
+    def test_local_push_banner_has_no_remote_lines(self, capsys):
+        print_success("octocat", "demo", local_push=True, protocol="ssh")
+        out = capsys.readouterr().out
+        assert "git remote add origin" not in out
+        assert "Set your tracking branch" in out


### PR DESCRIPTION
## Summary

Completes the last remaining (cosmetic) item of #19. The substantive parts — protocol detection and `--local` remote setup on the user's real repo — shipped with the `git_transport.py` refactor in #57. What was left: the **bare-create** and **`--from`** success banners still printed a static **HTTPS-first / SSH-second** block, ignoring the user's preferred git protocol.

## Changes

- **`git_transport.py`**: add public `git_protocol_preference()` wrapper around the existing gh-config lookup, so the banner can order suggestions without constructing a full `GitTransport`.
- **`commands/_common.py`**: `print_success()` now accepts `protocol=` and lists the preferred transport first (SSH-first when `ssh`, else HTTPS-first). `--local` push banner is unchanged (no remote lines).
- **`commands/create.py`**: thread the protocol in — `client.transport.protocol` when a transport exists (`--local`/`--from`), else `git_protocol_preference()` for bare create.
- **`tests/test_cli.py`**: 4 new tests covering both orderings, the default, and the local-push banner.

## Testing

`uv run pytest tests/ -q` → 548 passed, 7 skipped.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)