### PR TITLE
feat: remove auto_init README on plain create (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file was introduced with 0.2.0; the 0.2.0 entry backfills notable changes
 since the initial release.
 
+## [0.5.0] - 2026-07-05
+
+### Changed
+- Plain `create owner/repo` no longer leaves an auto-generated `README.md` in the
+  new repo by default. The repo still gets a default branch (still POSTs
+  `auto_init=true`, so branch protection works at create time and GitHub assigns
+  the account's preferred default-branch name), but the generated `README.md` is
+  removed via the Contents API afterward. The previously-ignored `auto_init`
+  config key now controls this: set `auto_init = true` to keep the initialized
+  README. `--local`/`--from` are unaffected (they always push your own history and
+  never create a README). (#54)
+
 ## [0.4.0] - 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ All commands that interact with GitHub require the `owner/repo` format (e.g. `my
 | `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
 | `--debug` | Print every API call and response |
 
+A plain `create` (no `--local`/`--from`) initializes the repo so a default branch
+exists for branch protection, then removes the auto-generated `README.md` so the
+new repo starts clean. Set `auto_init = true` in config to keep the README instead.
+`--local`/`--from` push your own history and never create a README.
+
 ### `fix` — Audit and fix an existing repo
 
 | Option | Description |
@@ -587,7 +592,11 @@ allow_squash_merge = true
 allow_merge_commit = true
 allow_rebase_merge = true
 
-# Do not initialize with a README — keeps the remote empty so pushing is seamless
+# Whether a plain `create` leaves an initialized README in the new repo.
+# false (default): the repo still gets a default branch (needed for branch
+#   protection), but the auto-generated README.md is removed afterward.
+# true: keep the initialized README.
+# (Ignored for --local/--from, which always push your own history instead.)
 auto_init = false
 
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -94,7 +94,9 @@ Technical notes accumulated during development. Moved from CLAUDE.md to keep the
 
 **Remote wiring on the original `local_path` is a separate, post-push step.** Non-fatal (wrapped in `try/except CalledProcessError`) so a pre-existing `origin` doesn't abort the workflow. The public URL (no token) is used.
 
-**`auto_init` must be `false` when `--local` or `--from` is used.** The config default is `auto_init = true`, which makes GitHub create an initial commit. When code is pushed immediately afterward, the push is rejected. Fix: `RepositoryPlugin` accepts an `auto_init: bool = None` constructor parameter.
+**`auto_init` must be `false` when `--local` or `--from` is used.** With `auto_init = true` GitHub creates an initial commit; when code is pushed immediately afterward, the push is rejected. Fix: `RepositoryPlugin` accepts an `auto_init: bool = None` constructor parameter, and `create.py` forces `False` for the `--local`/`--from` paths.
+
+**Plain `create` removes the README that `auto_init` creates (issue #54, Option D).** A branch cannot exist without a commit, and a commit needs content — so to get a default branch at create time (branch protection needs one, and GitHub assigns the account's preferred branch name from the initial commit) we must POST `auto_init=true`, which creates a `README.md`. To keep the repo clean, `create.py` computes `suppress_readme = is_plain_create and not config.getbool("repo", "auto_init")` and passes it to `RepositoryPlugin`; `remove_readme()` does a `GET .../contents/README.md` (404-retry backoff for post-create eventual consistency) then `DELETE` on the captured `created_default_branch`. It's best-effort — `create.py` wraps it and `warn()`s on failure so a delete hiccup doesn't fail the whole create. The `auto_init` config key (default `false`) now gates whether the README survives; alternatives (`.gitkeep` via Contents API, low-level git-data empty-tree commit, or local `git commit --allow-empty`) were rejected because the file-less ones force *us* to name the branch, losing the account's default-branch-name preference, and drag git transport onto the API-only plain-create path.
 
 ## `--json` Output
 

--- a/gh-safe-repo.ini.example
+++ b/gh-safe-repo.ini.example
@@ -17,7 +17,11 @@ allow_squash_merge = true
 allow_merge_commit = true
 allow_rebase_merge = true
 
-# Do not initialize with a README — keeps the remote empty so pushing is seamless
+# Whether a plain `create` leaves an initialized README in the new repo.
+# false (default): the repo still gets a default branch (needed for branch
+#   protection), but the auto-generated README.md is removed afterward.
+# true: keep the initialized README.
+# (Ignored for --local/--from, which always push your own history instead.)
 auto_init = false
 
 [actions]

--- a/gh_safe_repo/commands/create.py
+++ b/gh_safe_repo/commands/create.py
@@ -225,10 +225,18 @@ def run(args):
 
     # Plain create: auto_init=True so the repo has a branch for protection.
     # --local / --from: auto_init=False to avoid push rejection.
-    repo_auto_init = True if (not local_path and not args.from_repo) else False
+    is_plain_create = not local_path and not args.from_repo
+    repo_auto_init = True if is_plain_create else False
+    # The README auto_init creates is only a side-effect of needing a branch.
+    # Unless the user opts into an initialized README (auto_init = true), remove
+    # it after creation so the new repo is left clean.
+    suppress_readme = is_plain_create and not config.getbool(
+        "repo", "auto_init", fallback=False
+    )
     plugins = [
         RepositoryPlugin(client, owner, repo_name, config, auto_init=repo_auto_init,
-                         source_description=source_description, source_topics=source_topics),
+                         source_description=source_description, source_topics=source_topics,
+                         suppress_readme=suppress_readme),
         ActionsPlugin(client, owner, repo_name, config, is_public=is_public),
         BranchProtectionPlugin(client, owner, repo_name, config, is_public=is_public, is_paid_plan=is_paid_plan, branches=branches),
         SecurityPlugin(client, owner, repo_name, config, is_public=is_public, is_paid_plan=is_paid_plan),
@@ -332,6 +340,13 @@ def run(args):
     post_default = repo_plugin.created_default_branch
     if post_default:
         bp_plugin.branches = [post_default]
+
+    # Remove the auto_init README (before branch protection) unless the user
+    # opted into an initialized README via auto_init = true.
+    try:
+        repo_plugin.remove_readme()
+    except APIError as e:
+        warn(f"Repository created but README removal failed: {e}")
 
     # Apply Actions settings
     try:

--- a/gh_safe_repo/plugins/repository.py
+++ b/gh_safe_repo/plugins/repository.py
@@ -45,11 +45,13 @@ def _parse_bool(value):
 
 class RepositoryPlugin(BasePlugin):
     def __init__(self, client, owner, repo, config, auto_init: bool = None,
-                 source_description="", source_topics=None):
+                 source_description="", source_topics=None, suppress_readme: bool = False):
         super().__init__(client, owner, repo, config)
         self._auto_init_override = auto_init
         self._source_description = source_description or ""
         self._source_topics = source_topics or []
+        self._suppress_readme = suppress_readme
+        self.created_default_branch = None
 
     def fetch_current_state(self) -> dict:
         data = self.client.get_repo_data(self.owner, self.repo)
@@ -127,6 +129,16 @@ class RepositoryPlugin(BasePlugin):
                 )
             )
 
+        if not is_audit and self._suppress_readme:
+            plan.add(
+                Change(
+                    type=ChangeType.DELETE,
+                    category=ChangeCategory.FILE,
+                    key="readme",
+                    old="README.md",
+                )
+            )
+
         return plan
 
     def apply(self, plan: Plan) -> None:
@@ -188,3 +200,39 @@ class RepositoryPlugin(BasePlugin):
         if topics_change:
             path = self.client.repo_path(self.owner, self.repo)
             self.client.call_json("PUT", f"{path}/topics", {"names": self._source_topics})
+
+    def remove_readme(self) -> None:
+        """
+        Delete the README.md that ``auto_init=true`` created.
+
+        Plain create uses ``auto_init=true`` purely so a default branch exists
+        (branch protection needs one) and so GitHub assigns the account's
+        preferred branch name.  When the user has not opted into an initialized
+        README (``auto_init = false``, the default), remove the generated file
+        so the new repo is left clean.  Best-effort: callers wrap this and warn
+        on failure rather than failing the whole create.
+        """
+        if not self._suppress_readme:
+            return
+
+        path = self.client.repo_path(self.owner, self.repo, "contents/README.md")
+
+        # The repo may not be immediately readable after POST (GitHub eventual
+        # consistency), same as the PATCH block above.  Retry the sha lookup.
+        sha = None
+        for attempt in range(4):
+            try:
+                sha = self.client.get_json(path).get("sha")
+                break
+            except APIError as e:
+                if e.status_code == 404 and attempt < 3:
+                    time.sleep(1 << attempt)  # 1s, 2s, 4s
+                    continue
+                raise
+        if not sha:
+            return
+
+        body = {"message": "Remove auto-generated README", "sha": sha}
+        if self.created_default_branch:
+            body["branch"] = self.created_default_branch
+        self.client.call_json("DELETE", path, body)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gh-safe-repo"
-version = "0.4.0"
+version = "0.5.0"
 description = "Create GitHub repositories with safe defaults applied"
 requires-python = ">=3.10"
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -162,6 +162,77 @@ class TestRepositoryPlugin:
         ]
         assert len(topics_puts) == 0
 
+    def test_plan_includes_readme_delete_when_suppress(self):
+        client = make_mock_client()
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config(),
+                                  suppress_readme=True)
+        plan = plugin.plan()
+        readme = next(
+            (c for c in plan.changes
+             if c.type == ChangeType.DELETE
+             and c.category == ChangeCategory.FILE
+             and c.key == "readme"),
+            None,
+        )
+        assert readme is not None
+        assert readme.old == "README.md"
+
+    def test_plan_no_readme_delete_by_default(self):
+        client = make_mock_client()
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        plan = plugin.plan()
+        assert not any(c.key == "readme" for c in plan.changes)
+
+    def test_remove_readme_gets_sha_then_deletes(self):
+        client = make_mock_client()
+        client.get_json.return_value = {"sha": "abc123"}
+        client.call_json.return_value = {}
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config(),
+                                  suppress_readme=True)
+        plugin.created_default_branch = "main"
+        plugin.remove_readme()
+        client.get_json.assert_called_once_with("/repos/alice/my-repo/contents/README.md")
+        delete_calls = [c for c in client.call_json.call_args_list if c.args[0] == "DELETE"]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].args[1] == "/repos/alice/my-repo/contents/README.md"
+        body = delete_calls[0].args[2]
+        assert body["sha"] == "abc123"
+        assert body["branch"] == "main"
+
+    def test_remove_readme_omits_branch_when_unknown(self):
+        client = make_mock_client()
+        client.get_json.return_value = {"sha": "abc123"}
+        client.call_json.return_value = {}
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config(),
+                                  suppress_readme=True)
+        plugin.remove_readme()  # created_default_branch defaults to None
+        delete_calls = [c for c in client.call_json.call_args_list if c.args[0] == "DELETE"]
+        assert "branch" not in delete_calls[0].args[2]
+
+    def test_remove_readme_noop_when_not_suppress(self):
+        client = make_mock_client()
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config())
+        plugin.remove_readme()
+        client.get_json.assert_not_called()
+        assert not any(
+            c.args[0] == "DELETE" for c in client.call_json.call_args_list
+        )
+
+    @patch("gh_safe_repo.plugins.repository.time.sleep")
+    def test_remove_readme_retries_get_on_404(self, mock_sleep):
+        client = make_mock_client()
+        client.get_json.side_effect = [
+            APIError("not found", status_code=404),
+            {"sha": "abc123"},
+        ]
+        client.call_json.return_value = {}
+        plugin = RepositoryPlugin(client, "alice", "my-repo", make_config(),
+                                  suppress_readme=True)
+        plugin.remove_readme()
+        assert client.get_json.call_count == 2
+        delete_calls = [c for c in client.call_json.call_args_list if c.args[0] == "DELETE"]
+        assert len(delete_calls) == 1
+
     @patch("gh_safe_repo.plugins.repository.time.sleep")
     def test_apply_retries_patch_on_404_after_create(self, mock_sleep):
         """After POST /user/repos, a 404 on PATCH should be retried."""


### PR DESCRIPTION
Closes #54.

## What

Plain `create owner/repo` no longer leaves an auto-generated `README.md` in the new repo. It still POSTs `auto_init=true` so a default branch exists (branch protection needs one, and GitHub assigns the account's preferred default-branch name from the initial commit), then removes `README.md` via the Contents API afterward.

The previously-ignored `auto_init` config key now gates this behavior:
- `auto_init = false` (default) → branch created, README removed
- `auto_init = true` (opt-in) → branch created, README kept

`--local`/`--from` are unaffected — they push the user's own history and never create a README.

## Why Option D

Issue #54 evaluated four approaches. A branch can't exist without a commit, and a commit needs content, so any "branch at create time" requires an initial commit. Option D keeps GitHub naming the branch (preserving the account's default-branch-name preference) and yields a clean, file-less repo. The file-less alternatives (`.gitkeep`, git-data empty tree, `git commit --allow-empty`) were rejected because they force *us* to name the branch and/or drag git transport onto the otherwise API-only plain-create path. Cost: 2 extra API calls (GET sha + DELETE).

## Changes

- `commands/create.py` — compute `suppress_readme`, call `repo_plugin.remove_readme()` after creation and before branch protection (best-effort, `warn()`s on failure)
- `plugins/repository.py` — `suppress_readme` param; `DELETE`/`FILE` plan preview; `remove_readme()` (GET sha with 404 backoff for eventual consistency → DELETE on `created_default_branch`)
- Docs: `README.md`, `gh-safe-repo.ini.example`, `CHANGELOG.md` (0.5.0), `docs/LEARNINGS.md`; version bump in `pyproject.toml`

## Testing

- `uv run pytest tests/` → **554 passed, 7 skipped**. 6 new unit tests cover the plan preview (present/absent), GET-then-DELETE, branch omitted when unknown, no-op when not suppressing, and 404 retry.
- `create <owner/repo> --dry-run` renders `DELETE  file  readme  README.md` in the plan.

Note: `CLAUDE.md` has a matching design-invariant note in the working tree but is intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)