### PR TITLE
docs: restructure README for new-user readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,65 +6,268 @@ Create GitHub repositories with safe defaults applied automatically. Replaces th
 gh-safe-repo create <owner/repo>
 ```
 
-Branch protection, immutable tags, Dependabot, restricted Actions permissions, secret scanning with push protection, and disabled wiki and projects — all configured before you write your first line of code.  
+Branch protection, immutable tags, Dependabot, restricted Actions permissions, and secret scanning with push protection — all configured before you write your first line of code.
 
-gh-safe-repo is undergoing heavy development. It works well for the use-case of creating a new repo with secure defaults. I am working on polishing the CLI options to best align with users expectations. Expect breaking changes until we get to a point where I'm doing releases, and have CI/CD nailed down. ✌️
-
----
-
-## Table of Contents
-
-- [Why](#why)
-- [What It Changes](#what-it-changes)
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [CLI Reference](#cli-reference)
-- [Dry Run / Plan Output](#dry-run--plan-output)
-- [Fix Mode (Audit Existing Repos)](#fix-mode-audit-existing-repos)
-- [Mirroring Repos (`--from`)](#mirroring-repos---from)
-- [Creating a Repo from a Local Directory (`--local`)](#creating-a-repo-from-a-local-directory---local)
-- [Pre-flight Security Scanner](#pre-flight-security-scanner)
-  - [Standalone scan](#standalone-scan)
-  - [Suppressing false positives](#suppressing-false-positives)
-- [Configuration](#configuration)
-- [GitHub Plan Limitations](#github-plan-limitations)
-- [How It Works](#how-it-works)
-- [Development](#development)
+> **Status:** gh-safe-repo is undergoing heavy development. It works well for the core use case — creating a new repo with secure defaults — but the CLI options are still being polished to better match user expectations. Expect breaking changes until releases and CI/CD are nailed down. ✌️
 
 ---
 
-## Why
+## What you get
 
-GitHub's default repository settings are optimised for discoverability and flexibility, not security. Every new repo ships with:
+GitHub's defaults are optimised for discoverability and flexibility, not security: every new repo ships with no branch protection, no Dependabot, and Actions that have write access to the repo and can approve their own pull requests.
 
-- Wiki and Projects enabled (attack surface, even if unused)
-- Merge commits allowed (messy history, but not the main concern)
-- No branch protection (anyone with write access can push directly to `main`)
-- No Dependabot alerts
-- GitHub Actions with write permissions to the repository
-- Actions allowed to approve pull requests
+`gh-safe-repo` fixes all of that in one shot, showing you a plan first:
 
-Fixing all of this manually takes minutes per repo and is easy to forget. `gh-safe-repo` applies an opinionated but practical set of defaults in one shot, with a plan preview so you know exactly what will change before anything does.
+- **Private by default** — pass `--public` when you want the world to see it
+- **Branch protection** — PR required, 1 approving review, stale reviews dismissed, conversations resolved, no force pushes, no branch deletion
+- **Immutable tags** — release tags can't be rewritten or deleted
+- **Actions locked down** — read-only token, no self-approving PRs, SHA-pinned actions, GitHub-owned and verified publishers only
+- **Dependabot on** — vulnerability alerts plus automatic fix PRs
+- **Secret scanning with push protection** — commits containing supported secrets are blocked
+- **Private vulnerability reporting** — researchers can reach you without going public
+- **Pre-flight secret scan** — when pushing existing code (`--local` / `--from`), your working tree and git history are scanned locally before anything reaches GitHub
+- **Opt-in extras** — wiki, projects, and issues are left alone unless you ask for them to be managed (`has_wiki = false` in config)
+
+Everything is configurable. See [Safe defaults in full](#safe-defaults-in-full) for the exact settings and [Configuration](#configuration) for how to change them.
+
+## Requirements
+
+- **Python 3.10+**
+- **[`gh` CLI](https://cli.github.com/)** authenticated (`gh auth login`), **or** `GITHUB_TOKEN` set in your environment
+- **[`uv`](https://docs.astral.sh/uv/)** for installation from source
+- **truffleHog v3** *(optional)* — used by the pre-flight scanner; auto-detected from PATH or run via podman/docker, with a regex fallback if neither exists
+
+Pushing code with `--local` or `--from` additionally needs your normal git credentials for GitHub — see [Working from local or existing code](#working-from-local-or-existing-code).
+
+## Install
+
+```bash
+git clone https://github.com/AriESQ/gh-safe-repo
+cd gh-safe-repo
+uv tool install .
+
+gh-safe-repo --help
+```
+
+This installs `gh-safe-repo` into uv's tool environment and adds it to your `PATH`.
+
+To run it without installing:
+
+```bash
+uv sync                            # creates .venv
+./gh-safe-repo create <owner/repo>
+```
+
+## Your first repo
+
+**1. Preview.** `--dry-run` makes zero API calls — nothing is created:
+
+```
+$ gh-safe-repo create AriESQ/demo-repo --dry-run
+
+Configuring AriESQ/demo-repo...
+
+Planned Changes
+Type    Category           Setting                                 Value / Note
+------  -----------------  --------------------------------------  ----------------------------------------------------------------
+ADD     repo               repository                              AriESQ/demo-repo
+DELETE  file               readme                                  README.md
+UPDATE  actions            allowed_actions                         'all' → 'selected'
+UPDATE  actions            verified_allowed                        False → True
+UPDATE  actions            sha_pinning_required                    False → True
+UPDATE  actions            default_workflow_permissions            'write' → 'read'
+UPDATE  actions            can_approve_pull_request_reviews        True → False
+SKIP    branch_protection  branch_protection                       Branch protection requires a public repo or paid GitHub plan
+SKIP    security           dependabot_alerts                       Requires a public repo or paid GitHub plan
+SKIP    security           secret_scanning                         Requires a public repo or paid GitHub plan
+SKIP    security           dependabot_security_updates             Requires a public repo or paid GitHub plan
+SKIP    security           private_vulnerability_reporting         Requires a public repo or paid GitHub plan
+SKIP    security           enable_dependency_graph                 Requires a public repo or paid GitHub plan
+SKIP    security           enable_secret_scanning_push_protection  Requires a public repo or paid GitHub plan
+SKIP    tag_protection     tag_protection                          Tag protection rulesets require a public repo or paid GitHub plan
+
+7 change(s) to apply, 8 skipped
+
+Dry run — no changes made.
+```
+
+The `SKIP` rows above are a free-plan private repo: those features need a public repo or a paid plan. Nothing fails silently — see [GitHub plan limitations](#github-plan-limitations).
+
+**2. Apply.** Same command without `--dry-run`. You get the same plan, then a confirmation prompt (`--yes` skips it):
+
+```bash
+gh-safe-repo create AriESQ/demo-repo
+```
+
+**3. Start working.** On success you get the repo URL and ready-to-paste remote commands:
+
+```
+╭─ Done ───────────────────────────────────────────────────╮
+│   Repository created successfully!                       │
+│   https://github.com/AriESQ/demo-repo                    │
+│                                                          │
+│   Add remote to existing repo:                           │
+│   SSH  : git remote add origin git@github.com:AriESQ/…   │
+│   HTTPS: git remote add origin https://github.com/…      │
+│                                                          │
+│   Clone fresh:                                           │
+│   SSH  : git clone git@github.com:AriESQ/demo-repo.git   │
+│   HTTPS: git clone https://github.com/AriESQ/demo-…      │
+╰──────────────────────────────────────────────────────────╯
+```
+
+Remotes are listed with your preferred protocol first (`gh config get -h github.com git_protocol`).
+
+## Common tasks
+
+### Create a repo
+
+```bash
+gh-safe-repo create <owner/repo>            # private (default)
+gh-safe-repo create <owner/repo> --public   # public — branch and tag protection apply
+```
+
+A plain `create` initializes the repo so a default branch exists (branch protection needs one), then deletes the auto-generated `README.md` so you start clean. Set `auto_init = true` in config to keep it.
+
+### Push an existing local project
+
+```bash
+gh-safe-repo create <owner/repo> --local ~/projects/myapp
+```
+
+Scans the directory for secrets first, creates the repo, pushes all branches and tags, then wires up `origin` and upstream tracking in your original directory so `git push` works immediately. See [Working from local or existing code](#working-from-local-or-existing-code).
+
+### Mirror an existing repo
+
+```bash
+gh-safe-repo create <owner/repo> --from <owner/source>
+gh-safe-repo create <owner/pub> --from <owner/priv> --public   # the riskiest move — scanned thoroughly
+```
+
+Clones the source with full history, scans it, and mirrors it into a fresh repo with safe defaults. If you abort at the scan, no code ever reaches the new repo.
+
+### Audit a repo you already have
+
+```bash
+gh-safe-repo fix <owner/repo> --dry-run   # what's out of compliance?
+gh-safe-repo fix <owner/repo>             # apply the missing defaults
+gh-safe-repo fix <owner/repo> --yes       # no prompt, for scripts
+```
+
+`fix` fetches each setting's current value, shows `UPDATE` for what differs and `SKIP` for what's already correct, and makes no API calls for no-ops. It's settings-only — no secret scanning. You need admin on the repo, which can be one owned by an org or another account.
+
+### Scan without touching GitHub
+
+```bash
+gh-safe-repo scan .
+gh-safe-repo scan ~/projects/myapp
+```
+
+Local-only. Exit code `0` when there are no critical findings, `1` when there are, so it composes:
+
+```bash
+gh-safe-repo scan . && git push
+```
+
+See [Pre-flight security scanner](#pre-flight-security-scanner).
 
 ---
 
-## What It Changes
+## Reference
 
-### Repository settings
+### CLI reference
+
+```
+gh-safe-repo create <owner/repo> [OPTIONS]
+gh-safe-repo fix <owner/repo> [OPTIONS]
+gh-safe-repo scan <path> [OPTIONS]
+```
+
+All commands that interact with GitHub require the `owner/repo` format (e.g. `myuser/my-repo`). For `create`, the owner is validated against your authenticated GitHub account to prevent mistakes on multi-account systems. For `fix`, admin permissions on the target repo are required instead, allowing you to fix repos owned by organizations or other accounts where you have admin access.
+
+#### `create` — create a new repo
+
+| Option | Description |
+|---|---|
+| `--public` | Create as a public repo (default: private) |
+| `--local PATH` | Push code from a local git repository into the new repo. Runs pre-flight scan first. Mutually exclusive with `--from`. |
+| `--from OWNER/REPO` | Mirror code from an existing repo into the new repo. Runs pre-flight scan. Mutually exclusive with `--local`. |
+| `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
+| `--dry-run` | Print the plan without making any changes |
+| `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
+| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | Print every API call and response |
+
+#### `fix` — audit and fix an existing repo
+
+| Option | Description |
+|---|---|
+| `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
+| `--dry-run` | Show settings diff without applying changes |
+| `--migrate-branch-protection` | Convert existing classic branch protection to a ruleset (see [Branch protection](#branch-protection-public-repos-or-any-repo-on-a-paid-plan)) |
+| `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
+| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | Print every API call and response, plus resolved repo identity (id, full name, owner type) |
+
+#### `scan` — local secret scanning
+
+| Option | Description |
+|---|---|
+| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | Show scanner details |
+
+Exit code is `0` if no critical findings, `1` if criticals are found.
+
+### Plan output and JSON
+
+`--dry-run` shows exactly what `gh-safe-repo` would do, without making any changes or API calls. Combine with `--json` for machine-readable plan output:
+
+```bash
+gh-safe-repo create <owner/repo> --dry-run --json
+gh-safe-repo fix <owner/repo> --dry-run --json
+```
+
+When `--json` is active, the plan is written to stdout as a JSON object and all other messages (progress, warnings, the "Dry run" footer) go to stderr, so the output is clean for piping or scripting.
+
+**Change types** (the `Type` column, colourised in a terminal):
+
+| Type | Meaning |
+|---|---|
+| `ADD` (green) | New setting being applied |
+| `UPDATE` (yellow) | Existing setting being changed |
+| `DELETE` (red) | Setting or file being removed |
+| `SKIP` (dim) | No action needed — already at the desired value, or feature unavailable on your plan/visibility combination |
+
+**JSON output** (`--json`):
+
+```json
+{
+  "changes": [
+    { "type": "update", "category": "actions",         "key": "default_workflow_permissions", "old": "write", "new": "read", "reason": null },
+    { "type": "skip", "category": "branch_protection", "key": "branch_protection", "old": null, "new": null,  "reason": "Branch protection requires a public repo or paid GitHub plan" }
+  ],
+  "summary": { "add": 5, "skip": 2 }
+}
+```
+
+`summary` only includes types that are present in the plan. Consumers should use `.get("delete", 0)` etc. rather than assuming all four keys are present.
+
+### Safe defaults in full
+
+#### Repository settings
 
 | Setting | GitHub default | Safe default | Notes |
 |---|---|---|---|
 | Visibility | Public | **Private** | Pass `--public` to override |
-| Wiki | Enabled | **Disabled** | |
-| Projects | Enabled | **Disabled** | |
-| Issues | Enabled | Enabled | |
+| Wiki | Enabled | Not managed | Opt in with `has_wiki = false` in `[repo]` |
+| Projects | Enabled | Not managed | Opt in with `has_projects = false` |
+| Issues | Enabled | Not managed | Opt in with `has_issues = false` |
 | Delete branch on merge | Off | Off | Set to `true` in config for auto-cleanup |
 | Allow merge commits | On | On | Set to `false` in config for squash-only |
 | Allow squash merge | On | On | |
 | Allow rebase merge | On | On | |
 
-### GitHub Actions
+#### GitHub Actions
 
 | Setting | GitHub default | Safe default |
 |---|---|---|
@@ -74,7 +277,7 @@ Fixing all of this manually takes minutes per repo and is easy to forget. `gh-sa
 | Require SHA pinning | No | **Yes** (workflows must pin actions to a commit SHA, not a mutable tag) |
 | Fork PR approval policy | First-time contributors new to GitHub | **All external contributors** — require approval before fork PR workflows run CI. Options: brand-new GitHub accounts only (GitHub default), first-time repo contributors, or all fork PRs (safest) |
 
-### Branch protection (public repos, or any repo on a paid plan)
+#### Branch protection (public repos, or any repo on a paid plan)
 
 | Rule | Value |
 |---|---|
@@ -86,25 +289,17 @@ Fixing all of this manually takes minutes per repo and is easy to forget. `gh-sa
 | Allow branch deletion | No |
 | Enforce on admins | No (allows owner tooling to push) |
 
-Branch protection is applied via the **Rulesets API** by default (`use_rulesets =
-true`): a single `gh-safe-repo defaults` ruleset covers every configured branch
-and expresses "admins can bypass" through a bypass actor rather than the classic
-`enforce_admins` flag. Set `use_rulesets = false` for the legacy classic
-per-branch path (kept for one release cycle).
+Branch protection is applied via the **Rulesets API** by default (`use_rulesets = true`): a single `gh-safe-repo defaults` ruleset covers every configured branch and expresses "admins can bypass" through a bypass actor rather than the classic `enforce_admins` flag. Set `use_rulesets = false` for the legacy classic per-branch path (kept for one release cycle).
 
-**Migrating an existing repo from classic protection:** if `fix` finds classic
-branch protection on a repo, it refuses to convert it to a ruleset unless you pass
-`--migrate-branch-protection`. Classic-only rules have no equivalent in the ruleset
-this tool builds and would be dropped silently otherwise — known gaps:
+**Migrating an existing repo from classic protection:** if `fix` finds classic branch protection on a repo, it refuses to convert it to a ruleset unless you pass `--migrate-branch-protection`. Classic-only rules have no equivalent in the ruleset this tool builds and would be dropped silently otherwise — known gaps:
 
 - `required_status_checks` — required CI checks are not modelled in the ruleset body.
 - `restrictions` (push restrictions by user/team) — Rulesets model this differently via bypass actors; not a 1:1 map.
 - Per-branch divergence — a single shared-condition ruleset can't express different rules for `master` vs `main`.
 
-With the flag, `fix` creates/updates the ruleset and then deletes the classic
-protection on each branch so the two layers don't stack.
+With the flag, `fix` creates/updates the ruleset and then deletes the classic protection on each branch so the two layers don't stack.
 
-### Tag protection (public repos, or any repo on a paid plan)
+#### Tag protection (public repos, or any repo on a paid plan)
 
 Tag protection creates a GitHub Ruleset targeting all tags (`*` by default, configurable via `protected_tags`). The following rules are enforced:
 
@@ -121,7 +316,7 @@ Tag protection creates a GitHub Ruleset targeting all tags (`*` by default, conf
 
 Repository admins are on the bypass list (consistent with the branch protection `enforce_admins = false` default). Only works on public repos or paid GitHub plans (same restriction as branch protection). Free-plan private repos will see this skipped in the plan output.
 
-### Security
+#### Security
 
 | Feature | Behaviour |
 |---|---|
@@ -132,295 +327,44 @@ Repository admins are on the bypass list (consistent with the branch protection 
 | Private vulnerability reporting | Enabled (lets security researchers report privately) |
 | Dependency graph | Automatic on public repos; no REST API for private (UI only) |
 
----
+### Working from local or existing code
 
-## Requirements
+`--local PATH` and `--from OWNER/REPO` both create a new repo *and* populate it with code. They are mutually exclusive, and both work for private and public destinations.
 
-- Python 3.8+
-- [`gh` CLI](https://cli.github.com/) installed and authenticated (`gh auth login`), **or** `GITHUB_TOKEN` set in your environment
-- For `--local` / `--from` (which push or clone code): your usual git credentials must be set up — either an SSH key loaded into `ssh-agent` (when `gh config get git_protocol` is `ssh`) or an HTTPS credential helper (`gh auth setup-git` configures one automatically). The OAuth token is **not** used for git push, so workflow files (`.github/workflows/*`) push without needing the OAuth `workflow` scope.
-- [`uv`](https://docs.astral.sh/uv/) for installation from source (recommended)
-- `truffleHog` v3 (optional — used by the pre-flight scanner; auto-detected from PATH, or run via podman/docker; falls back to regex if neither is available)
+**Git credentials.** Both push over git transport using your own credentials, not the API token: an SSH key loaded into `ssh-agent` when `gh config get -h github.com git_protocol` is `ssh`, or an HTTPS credential helper (`gh auth setup-git` configures one). This is deliberate — the OAuth token would need the `workflow` scope to push `.github/workflows/*` files. In environments with neither (e.g. CI with only `GITHUB_TOKEN`), the tool falls back to HTTPS with the token in the URL; see `[git_transport] mode` in [Configuration](#configuration).
 
----
+**`--local PATH`** — `PATH` must be an initialized git repository (`git init` or a clone):
 
-## Installation
+1. Your git credentials for `github.com` are verified up front (SSH probe when the protocol is `ssh`; HTTPS is trusted), so a missing key fails fast before any repo is created
+2. The [pre-flight security scanner](#pre-flight-security-scanner) runs on the local directory directly (no clone needed)
+3. You review findings and confirm (or abort)
+4. The repo is created, and actions permissions and security settings are applied
+5. History is pushed with `push --all --tags` (all branches and tags)
+6. Branch and tag protection are applied — after the push, so the target branch exists
+7. `origin` is added to your **original** local repo pointing at the new GitHub URL, and the current branch's upstream is configured, so `git push` and `git pull` work immediately
 
-### From source with uv (recommended)
+The local default branch (via `git -C PATH symbolic-ref HEAD`) is used to target branch protection, so protection lands on the right branch even if it isn't `main`.
 
-```bash
-git clone https://github.com/your-username/gh-safe-repo
-cd gh-safe-repo
-uv tool install .
-```
+**`--from OWNER/REPO`** — the remote-to-remote counterpart:
 
-This installs `gh-safe-repo` into uv's tool environment and adds it to your `PATH`.
-
-### Run directly without installing
-
-```bash
-git clone https://github.com/your-username/gh-safe-repo
-cd gh-safe-repo
-uv sync           # creates .venv
-./gh-safe-repo create <owner/repo>
-```
-
-### Verify
-
-```bash
-gh-safe-repo --help
-```
-
----
-
-## Quick Start
-
-```bash
-# Create a private repo with all safe defaults
-gh-safe-repo create <owner/repo>
-
-# Preview what would happen — no changes made
-gh-safe-repo create <owner/repo> --dry-run
-
-# Create a public repo (branch protection + security scanning applied)
-gh-safe-repo create <owner/repo> --public
-
-# Mirror an existing repo into a new private repo (with pre-flight scan)
-gh-safe-repo create <owner/repo> --from <owner/source>
-
-# Mirror a private repo to a new public repo (with pre-flight scan)
-gh-safe-repo create <owner/pub> --from <owner/priv> --public
-
-# Create a repo from a local directory (with pre-flight scan)
-gh-safe-repo create <owner/repo> --local ~/projects/myapp
-
-# Same, but make it public (branch protection applied before push)
-gh-safe-repo create <owner/repo> --local ~/projects/myapp --public
-
-# Audit an existing repo and apply any missing safe defaults
-gh-safe-repo fix <owner/repo>
-
-# Audit without making changes
-gh-safe-repo fix <owner/repo> --dry-run
-
-# Apply fixes without confirmation prompt (scripting/batch use)
-gh-safe-repo fix <owner/repo> --yes
-
-# Scan a local repo for secrets before pushing anywhere
-gh-safe-repo scan .
-gh-safe-repo scan ~/projects/myapp
-```
-
----
-
-## CLI Reference
-
-```
-gh-safe-repo create <owner/repo> [OPTIONS]
-gh-safe-repo fix <owner/repo> [OPTIONS]
-gh-safe-repo scan <path> [OPTIONS]
-```
-
-All commands that interact with GitHub require the `owner/repo` format (e.g. `myuser/my-repo`). For `create`, the owner is validated against your authenticated GitHub account to prevent mistakes on multi-account systems. For `fix`, admin permissions on the target repo are required instead, allowing you to fix repos owned by organizations or other accounts where you have admin access.
-
-### `create` — Create a new repo
-
-| Option | Description |
-|---|---|
-| `--public` | Create as a public repo (default: private) |
-| `--local PATH` | Push code from a local git repository into the new repo. Runs pre-flight scan first. Mutually exclusive with `--from`. |
-| `--from OWNER/REPO` | Mirror code from an existing repo into the new repo. Runs pre-flight scan. Mutually exclusive with `--local`. |
-| `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
-| `--dry-run` | Print the plan without making any changes |
-| `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Print every API call and response |
-
-A plain `create` (no `--local`/`--from`) initializes the repo so a default branch
-exists for branch protection, then removes the auto-generated `README.md` so the
-new repo starts clean. Set `auto_init = true` in config to keep the README instead.
-`--local`/`--from` push your own history and never create a README.
-
-### `fix` — Audit and fix an existing repo
-
-| Option | Description |
-|---|---|
-| `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
-| `--dry-run` | Show settings diff without applying changes |
-| `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Print every API call and response, plus resolved repo identity (id, full name, owner type) |
-
-### `scan` — Local secret scanning
-
-| Option | Description |
-|---|---|
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Show scanner details |
-
-Exit code is `0` if no critical findings, `1` if criticals are found.
-
----
-
-## Dry Run / Plan Output
-
-`--dry-run` shows exactly what `gh-safe-repo` would do, without making any changes or API calls. Use it before running for real. Combine with `--json` for machine-readable plan output:
-
-```bash
-gh-safe-repo create <owner/repo> --dry-run --json
-gh-safe-repo fix <owner/repo> --dry-run --json
-```
-
-When `--json` is active, the plan is written to stdout as a JSON object and all other messages (progress, warnings, the "Dry run" footer) go to stderr, so the output is clean for piping or scripting.
-
-```
-$ gh-safe-repo create <owner/repo> --dry-run
-
-  Plan for my-project (private)
-
-  Category            Action  Setting                          Value
-  ──────────────────────────────────────────────────────────────────
-  Repository          ADD     repository                       my-project (private)
-  Repository          ADD     has_wiki                         false
-  Repository          ADD     has_projects                     false
-  Actions             ADD     default_workflow_permissions     read
-  Actions             ADD     can_approve_pull_request_reviews false
-  Branch Protection   SKIP    branch_protection                Not available for private repos on free plan
-  Security            SKIP    dependabot_alerts                Not available for private repos on free plan
-  1 setting skipped (GitHub plan limitation).
-  Dry run — no changes made.
-```
-
-**Action colours:**
-
-| Action | Meaning |
-|---|---|
-| `ADD` (green) | New setting being applied |
-| `UPDATE` (yellow) | Existing setting being changed (audit mode) |
-| `DELETE` (red) | Setting being removed |
-| `SKIP` (dim) | No action needed — already at the desired value, or feature unavailable on your plan/visibility combination |
-
-**JSON output** (`--json`):
-
-```json
-{
-  "changes": [
-    { "type": "add",  "category": "repository",         "key": "has_wiki",  "old": null, "new": false, "reason": null },
-    { "type": "skip", "category": "branch_protection",   "key": "branch_protection", "old": null, "new": null, "reason": "Not available for private repos on free plan" }
-  ],
-  "summary": { "add": 5, "skip": 2 }
-}
-```
-
-`summary` only includes types that are present in the plan. Consumers should use `.get("delete", 0)` etc. rather than assuming all four keys are present.
-
----
-
-## Fix Mode (Audit Existing Repos)
-
-`fix` compares an existing repo's current settings against the safe defaults and applies any corrections. No secret scanning — `fix` is purely about repo settings.
-
-```bash
-# See what's out of compliance
-gh-safe-repo fix <owner/repo> --dry-run
-
-# Apply missing safe defaults
-gh-safe-repo fix <owner/repo>
-
-# Apply without confirmation prompt (scripting/batch use)
-gh-safe-repo fix <owner/repo> --yes
-```
-
-Fix mode:
-
-1. Fetches the current value of every setting via the GitHub API
-2. Compares against desired safe defaults
-3. Shows a plan table with `UPDATE` for changed settings and `SKIP` for settings already at the desired value (no-op detection — it never makes API calls that would change nothing)
-4. Prompts for confirmation before applying (skip with `--yes`)
-
-Only real changes are applied — settings already at the desired value are shown as `SKIP` and generate no API calls.
-
----
-
-## Mirroring Repos (`--from`)
-
-`--from` mirrors an existing repo into a new one with safe defaults. It works for both private and public destinations:
-
-```bash
-# Mirror into a new private repo (default)
-gh-safe-repo create <owner/repo> --from <owner/source>
-
-# Mirror a private repo to a new public repo (riskiest operation — scanned thoroughly)
-gh-safe-repo create <owner/pub> --from <owner/priv> --public
-```
-
-**What happens, in order:**
-
-1. Your git credentials for `github.com` are verified up front (SSH probe when `gh config get git_protocol` is `ssh`; HTTPS is trusted), so a missing key fails fast before any repo is created
-2. The source repo is cloned locally (full clone, no `--depth`, so truffleHog can walk the full commit history)
-3. The [pre-flight security scanner](#pre-flight-security-scanner) runs on the local clone
+1. Git credentials are verified up front, same as above
+2. The source repo is cloned locally (full clone, no `--depth`, so truffleHog can walk the entire commit history)
+3. The [pre-flight security scanner](#pre-flight-security-scanner) runs on the clone
 4. You review findings and confirm (or abort)
-5. A new repo is created (private by default, or public with `--public`)
-6. Actions permissions and security settings are applied (Dependabot, secret scanning, push protection)
-7. The full history is mirrored: `git clone --mirror` + `git push --mirror`
-8. Branch and tag protection are applied (after code push, so the target branch exists)
+5. The new repo is created (private by default, or public with `--public`)
+6. Actions permissions and security settings are applied
+7. Full history is mirrored: `git clone --mirror` + `git push --mirror`
+8. Branch and tag protection are applied
 
 If the scan reveals a problem and you abort, no code is ever copied to GitHub.
 
-> **Note:** `--from` uses `owner/repo` format for both the source and destination.
+> **Tip:** run `gh-safe-repo scan PATH` first if you want to inspect findings without creating anything.
 
----
+### Pre-flight security scanner
 
-## Creating a Repo from a Local Directory (`--local`)
+The scanner runs locally and never sends code to GitHub. Use it standalone (`gh-safe-repo scan <path>`) before any push, or let it run automatically as part of the `--from` and `--local` workflows. The full `[pre_flight_scan]` config applies in both cases.
 
-`--local PATH` is the local-to-GitHub counterpart to `--from`. It creates a new GitHub repo and pushes code from a local git repository. `PATH` must be an initialized git repository (`git init` or a clone).
-
-```bash
-gh-safe-repo create <owner/repo> --local ~/projects/myapp
-gh-safe-repo create <owner/repo> --local ~/projects/myapp --public
-```
-
-**What happens, in order:**
-
-1. Your git credentials for `github.com` are verified up front (SSH probe when `gh config get git_protocol` is `ssh`; HTTPS is trusted), so a missing key fails fast before any repo is created
-2. The [pre-flight security scanner](#pre-flight-security-scanner) runs on the local directory directly (no clone needed)
-3. You review findings and confirm (or abort)
-4. A new repo is created, and actions permissions and security settings are applied
-5. The full history is pushed with `push --all --tags` (all branches and tags)
-6. Branch and tag protection are applied (after code push, so the target branch exists)
-7. `origin` is added to the **original** local repo pointing at the new GitHub URL, and the current branch's upstream tracking is configured — so `git push` and `git pull` work immediately without extra setup.
-
-Both `--local` and `--from` work for private and public repos. They are mutually exclusive.
-
-The local default branch (via `git -C PATH symbolic-ref HEAD`) is used to target branch protection rules, so protection lands on the right branch even if it isn't `main`.
-
-> **Tip:** Run `gh-safe-repo scan PATH` first if you want to inspect findings without creating anything.
-
----
-
-## Pre-flight Security Scanner
-
-The scanner runs locally and never sends code to GitHub. Use it standalone before any push, or it runs automatically as part of the `--from` and `--local` workflows.
-
-### Standalone scan
-
-```bash
-# Scan the current directory
-gh-safe-repo scan .
-
-# Scan an explicit path
-gh-safe-repo scan ~/projects/myapp
-```
-
-Exit code is `0` if no critical findings, `1` if criticals are found — so it composes cleanly with other commands:
-
-```bash
-gh-safe-repo scan . && git push
-```
-
-The full `[pre_flight_scan]` config applies: `banned_strings`, `max_file_size_mb`, `trufflehog_mode`, etc.
-
-### What it detects
+#### What it detects
 
 | Category | Severity | Examples |
 |---|---|---|
@@ -431,31 +375,7 @@ The full `[pre_flight_scan]` config applies: `banned_strings`, `max_file_size_mb
 | Large files | Warning | Files over the configured size threshold (default: 100 MB) |
 | TODO/FIXME comments | Info | `# TODO`, `# FIXME`, `# HACK`, `# XXX` |
 
-### Scanner engine
-
-`gh-safe-repo` automatically picks the best available scanner using a three-step discovery chain:
-
-1. **truffleHog v3 on PATH** — runs `trufflehog --version`, verifies it is v3, and uses it. A v2 install or an unrecognised version prints a warning and falls through to step 2.
-2. **podman or docker** — if no native truffleHog is found, the scanner runs truffleHog in a container (`ghcr.io/trufflesecurity/trufflehog:latest`) using `podman run` or `docker run`, mounting the scan path read-only at the same absolute path so JSON output paths are identical to a native run.
-3. **Regex fallback** — if neither a native install nor a container runtime is available, a warning is printed and the regex scanner runs instead. It also always runs in addition to truffleHog for emails and TODOs, and catches lone key-ID patterns that truffleHog deliberately skips (truffleHog requires both halves of a credential pair, e.g. AWS Key ID *and* Secret Access Key, before flagging a finding).
-
-The selected scanner is shown in the "Running pre-flight security scan..." header and in the plan table's SCAN entry, e.g.:
-
-```
-Running pre-flight security scan... (truffleHog v3.93.4)
-Running pre-flight security scan... (truffleHog via podman)
-Running pre-flight security scan... (regex only — see warning above)
-```
-
-Environment variables respected by the container path: `CONTAINER_RUNTIME` to override runtime selection (e.g. `CONTAINER_RUNTIME=docker`), and `TRUFFLEHOG_IMAGE` to pin a specific image tag.
-
-### Running truffleHog via podman or Docker (no local install)
-
-No manual setup is required. `gh-safe-repo` detects podman or docker automatically (step 2 above) and runs truffleHog in a container with the correct volume mounts. `CONTAINER_RUNTIME` and `TRUFFLEHOG_IMAGE` environment variables are respected.
-
-A shell wrapper (`tools/trufflehog`) and a `Containerfile` for building a pinned local image are provided in [`tools/`](tools/README.md) for users who want container-based truffleHog available system-wide, or who need an air-gapped image.
-
-### Interactive review
+#### Interactive review
 
 ```
 Pre-flight scan: my-private-project
@@ -471,25 +391,39 @@ Pre-flight scan: my-private-project
   Critical findings detected. Continue anyway? [y/N]:
 ```
 
-- **Critical findings:** Default is abort (`N`). You must explicitly type `y` to continue.
-- **Warnings only:** Default is continue (`Y`). Press Enter to proceed or type `n` to abort.
-- **No findings:** Scan completes silently and the workflow continues.
+- **Critical findings:** default is abort (`N`). You must explicitly type `y` to continue.
+- **Warnings only:** default is continue (`Y`). Press Enter to proceed or type `n` to abort.
+- **No findings:** the scan completes silently and the workflow continues.
 
-Secrets are redacted in the output. Email addresses and TODOs show the matching line.
+Secrets are redacted in the output. Email addresses and TODOs show the matching line. When banned strings or AI context files are found, the scanner prints a ready-to-run `git filter-repo` command to remove them from the source repo's history before re-running.
 
-### Scan coverage
+#### Scanner engine
 
-Build-artifact directories (`node_modules`, `__pycache__`, `.venv`, `venv`, `dist`, `build`) are skipped by default to keep scans fast. In git repos, this skip is conditional: before pruning a directory, the scanner runs `git ls-files -- <dir>` to check whether any files inside are tracked. If they are, the directory is scanned normally.
+`gh-safe-repo` automatically picks the best available scanner using a three-step discovery chain:
 
-This means committed `node_modules` or `dist` trees — unusual, but they happen — are not silently missed. Uncommitted directories (the normal case) continue to be skipped as before.
+1. **truffleHog v3 on PATH** — runs `trufflehog --version`, verifies it is v3, and uses it. A v2 install or an unrecognised version prints a warning and falls through to step 2.
+2. **podman or docker** — if no native truffleHog is found, the scanner runs truffleHog in a container (`ghcr.io/trufflesecurity/trufflehog:latest`), mounting the scan path read-only at the same absolute path so JSON output paths match a native run.
+3. **Regex fallback** — if neither is available, a warning is printed and the regex scanner runs instead. It also always runs *in addition to* truffleHog for emails and TODOs, and catches lone key-ID patterns that truffleHog deliberately skips (truffleHog requires both halves of a credential pair, e.g. AWS Key ID *and* Secret Access Key, before flagging a finding).
 
-A warning is still printed when SKIP_DIRS subdirectories are found in a cloned source repo, since their presence may indicate that more content than expected is committed.
+The selected scanner is shown in the scan header and in the plan table's SCAN entry:
 
-### Suppressing false positives
+```
+Running pre-flight security scan... (truffleHog v3.93.4)
+Running pre-flight security scan... (truffleHog via podman)
+Running pre-flight security scan... (regex only — see warning above)
+```
 
-Two config keys let you suppress known-safe findings without disabling entire check categories.
+Set `trufflehog_mode` in config to pin a specific engine. Two environment variables affect the container path: `CONTAINER_RUNTIME` overrides runtime selection (e.g. `CONTAINER_RUNTIME=docker`), and `TRUFFLEHOG_IMAGE` pins a specific image tag. No manual container setup is required, but a shell wrapper (`tools/trufflehog`) and a `Containerfile` for building a pinned local image are provided in [`tools/`](tools/README.md) for system-wide or air-gapped use.
 
-**`scan_exclude_paths`** — skip files or directories entirely. Values are newline/comma-separated regex patterns matched against the relative file path. A matching file is excluded from every check: secrets, emails, TODOs, large files, and AI context file detection. The same patterns are also passed to truffleHog via `--exclude-paths`, so coverage is consistent regardless of which scanner engine is active.
+#### Scan coverage
+
+Build-artifact directories (`node_modules`, `__pycache__`, `.venv`, `venv`, `dist`, `build`) are skipped by default to keep scans fast. In git repos this skip is conditional: before pruning a directory, the scanner runs `git ls-files -- <dir>` to check whether any files inside are tracked. If they are, the directory is scanned normally — so committed `node_modules` or `dist` trees are not silently missed. A warning is still printed when such directories are found in a cloned source repo, since their presence may indicate more content is committed than expected.
+
+#### Suppressing false positives
+
+Two config keys suppress known-safe findings without disabling entire check categories.
+
+**`scan_exclude_paths`** — skip files or directories entirely. Values are newline/comma-separated regex patterns matched against the relative file path. A matching file is excluded from every check: secrets, emails, TODOs, large files, and AI context file detection. The same patterns are passed to truffleHog via `--exclude-paths`, so coverage is consistent regardless of engine.
 
 ```ini
 [pre_flight_scan]
@@ -506,50 +440,9 @@ scan_exclude_paths = docs/api\.github\.com\.json
 exclude_emails = action@github.com, noreply@github.com, @example.com
 ```
 
-### Scanner configuration
+The remaining scanner keys are documented in [Configuration](#configuration) below.
 
-```ini
-[pre_flight_scan]
-scan_for_secrets = true
-scan_for_emails = true
-scan_for_todos = true
-max_file_size_mb = 100
-
-# Scan git history for email addresses (requires scan_for_emails = true)
-# scan_email_history = true
-
-# Scanner selection: auto | native | docker | off
-#   auto   — try native truffleHog, fall back to container (podman/docker), then regex (default)
-#   native — native truffleHog only; no container fallback
-#   docker — container only; skip native PATH check
-#   off    — regex scanner only, no truffleHog attempt
-# trufflehog_mode = auto
-
-# Flag AI context files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) as critical findings.
-# Their git history may contain more sensitive content than the current version.
-# warn_ai_context_files = true
-
-# Literal strings to flag as critical findings (case-insensitive).
-# Comma-separated or one per line (continuation lines must be indented).
-# banned_strings = secret
-#     password
-#     credential
-
-# Exclude files/directories from all scan checks (regex patterns, comma/newline separated).
-# The same patterns are passed to truffleHog via --exclude-paths.
-# scan_exclude_paths = docs/api\.github\.com\.json
-#     tests/fixtures/
-
-# Suppress email findings for specific addresses or entire domains (case-insensitive).
-# Entries starting with @ match all emails at that domain; otherwise exact address match.
-# exclude_emails = action@github.com, noreply@github.com, @example.com
-```
-
-When banned strings or AI context files are found the scanner prints a ready-to-run `git filter-repo` command to remove them from the source repo's history before re-running.
-
----
-
-## Configuration
+### Configuration
 
 `gh-safe-repo` looks for configuration in this order (first match wins):
 
@@ -557,10 +450,9 @@ When banned strings or AI context files are found the scanner prints a ready-to-
 2. **`./gh-safe-repo.ini`** — current working directory
 3. **`$XDG_CONFIG_HOME/gh-safe-repo/gh-safe-repo.ini`** — defaults to `~/.config` when `$XDG_CONFIG_HOME` is unset
 
-Bare `--config` (no path) skips file lookup entirely and uses built-in defaults only.
-All values have safe defaults — no config file is required to get started.
+Bare `--config` (no path) skips file lookup entirely and uses built-in defaults only. All values have safe defaults — no config file is required to get started.
 
-A fully-annotated example config is included in the repository as `gh-safe-repo.ini.example`. Copy it to get started:
+**`gh-safe-repo.ini.example` in the repository root is the canonical, fully-annotated reference** — every key with its default and a comment. `tests/test_config_consistency.py` fails if it drifts from `SAFE_DEFAULTS` in `gh_safe_repo/config_manager.py`, so it is always current. Copy it to get started:
 
 ```bash
 # User-level config (XDG)
@@ -571,175 +463,121 @@ cp gh-safe-repo.ini.example "${XDG_CONFIG_HOME:-$HOME/.config}/gh-safe-repo/gh-s
 cp gh-safe-repo.ini.example ./gh-safe-repo.ini
 ```
 
-### Full configuration reference
+The abridged reference below shows the keys and their defaults; see the example file for the full commentary.
 
 ```ini
 [repo]
-# Whether new repos are private by default
 private = true
-
-# Disable features that create clutter if unused
-has_wiki = false
-has_projects = false
-has_issues = true
-
-# Auto-delete head branches after merge (default: off, matching GitHub)
 delete_branch_on_merge = false
 
-# Merge strategies (all enabled by default, matching GitHub)
-# Set allow_merge_commit = false for squash-only workflows
+# Not managed unless you set them. Uncomment to have gh-safe-repo enforce them:
+# has_wiki = false
+# has_projects = false
+# has_issues = false
+
+# Merge strategies — at least one must stay true (GitHub rejects all-false with a 422)
 allow_squash_merge = true
 allow_merge_commit = true
 allow_rebase_merge = true
 
-# Whether a plain `create` leaves an initialized README in the new repo.
+# Whether a plain `create` leaves the initialized README in the new repo.
 # false (default): the repo still gets a default branch (needed for branch
 #   protection), but the auto-generated README.md is removed afterward.
-# true: keep the initialized README.
-# (Ignored for --local/--from, which always push your own history instead.)
+# (Ignored for --local/--from, which push your own history instead.)
 auto_init = false
 
 
 [actions]
-# Which actions are allowed to run: all | local_only | selected
+enabled = true
+
+# all | local_only | selected
 allowed_actions = selected
 
-# When allowed_actions = selected, control which external actions are permitted:
+# Only consulted when allowed_actions = selected:
 github_owned_allowed = true       # actions maintained by GitHub (e.g. actions/checkout)
 verified_allowed = true           # actions from Marketplace verified creators
 # patterns_allowed = myorg/*      # comma-separated allowlist (wildcards OK)
 
-# Principle of least privilege: read-only by default
-# Options: read | write
+# read | write
 default_workflow_permissions = read
-
-# Prevent Actions from self-approving pull requests
 can_approve_pull_request_reviews = false
-
-# Require workflows to pin actions to a specific commit SHA instead of a mutable tag
 sha_pinning_required = true
+
+# Who needs approval before their fork PR runs CI:
+#   all_external_contributors | first_time_contributors | first_time_contributors_new_to_github
+fork_pr_approval_policy = all_external_contributors
 
 
 [branch_protection]
 # Applied to public repos on any plan, and private repos on paid plans.
-
-# Branch to protect
-protected_branch = main
-
-# Require a pull request before merging
+# Comma-separated; branches that don't exist are ignored.
+protected_branch = master, main
 require_pull_request = true
-
-# Number of approvals required
 required_approving_reviews = 1
-
-# Dismiss existing approvals when new commits are pushed
 dismiss_stale_reviews = true
-
-# Require all review comments to be resolved before merging
 require_conversation_resolution = true
-
-# Do not enforce rules on administrators
-# false = repo owner can still push directly (needed for --from mirror workflow)
-enforce_admins = false
-
-# Block force-pushes
 allow_force_pushes = false
-
-# Block branch deletion
 allow_deletions = false
 
+# false = repo owner can still push directly (needed for the --from mirror workflow)
+enforce_admins = false
+
 # Use the Rulesets API (default) instead of the legacy classic branch-protection
-# path. A single ruleset covers all configured branches, supports bypass actors,
-# and is GitHub's forward direction (new rule types are Rulesets-only). Set false
-# to fall back to the classic per-branch API, which is kept for one release cycle.
+# path. Set false to fall back to the classic per-branch API, kept for one
+# release cycle.
 use_rulesets = true
 
 
 [tag_protection]
-# Immutable tags via Rulesets API.
-# Only works on public repos or paid GitHub plans (same restriction as branch protection).
-# Glob pattern(s) for tags to protect — comma-separated.
-protected_tags = *
-
-# Prevent deletion of matching tags (git tag -d / git push --delete)
-prevent_tag_deletion = true
-
-# Prevent rewriting matching tags (git tag -f / force-push)
-prevent_tag_update = true
+# Immutable tags via Rulesets API. Public repos or paid plans only.
+protected_tags = *                # comma-separated glob patterns
+prevent_tag_deletion = true       # blocks git push --delete
+prevent_tag_update = true         # blocks git tag -f / force-push
 
 
 [security]
-# Enable Dependabot vulnerability alerts
 enable_dependabot_alerts = true
-
-# Auto-open PRs to fix vulnerable dependencies
 enable_dependabot_security_updates = true
-
-# Let security researchers report vulnerabilities privately
 enable_private_vulnerability_reporting = true
-
-# Block commits that contain supported secrets
 enable_secret_scanning_push_protection = true
 
-# Note: The following features have no REST API and must be configured via UI or dependabot.yml:
-#   - Grouped security updates: use dependabot.yml groups with applies-to: security-updates
-#   - Automatic dependency submission: enable via repository settings UI
-#   - Dependency graph: automatic for public repos; enable via UI for private repos
+# No REST API exists for these — configure via UI or dependabot.yml:
+#   grouped security updates (dependabot.yml groups with applies-to: security-updates),
+#   automatic dependency submission (UI), dependency graph on private repos (UI)
 
 
 [pre_flight_scan]
 scan_for_secrets = true
 scan_for_emails = true
 scan_for_todos = true
-
-# Flag files larger than this threshold
 max_file_size_mb = 100
+scan_email_history = true         # also scan git history for addresses
+warn_ai_context_files = true      # flag CLAUDE.md, .cursorrules, etc. as critical
 
-# Scan git history for email addresses (requires scan_for_emails = true)
-# scan_email_history = true
+# auto | native | docker | off — see "Scanner engine" above
+trufflehog_mode = auto
 
-# Scanner selection: auto | native | docker | off
-# auto   = try native truffleHog, fall back to container (podman/docker), then regex
-# native = native PATH only
-# docker = container only
-# off    = regex only
-# trufflehog_mode = auto
-
-# Flag AI context files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) as critical findings.
-# warn_ai_context_files = true
-
-# Literal strings to flag as critical findings (case-insensitive).
-# Comma-separated, or one per line with continuation indentation.
+# Comma-separated or one per line with continuation indentation:
 # banned_strings = secret
 #     password
-#     credential
-
-# Exclude files/directories from all scan checks (regex patterns, comma/newline separated).
-# Passed to truffleHog via --exclude-paths as well as applied to the regex walk.
 # scan_exclude_paths = docs/api\.github\.com\.json
 #     tests/fixtures/
-
-# Suppress email findings for specific addresses or entire domains (case-insensitive).
-# Entries starting with @ match all emails at that domain; otherwise exact address match.
 # exclude_emails = action@github.com, noreply@github.com, @example.com
 
+
 [git_transport]
-# How git push/clone authenticates when using --local or --from: auto | user_creds | token
-#   auto       — use your own git credentials (SSH key or credential helper) when a
-#                path exists; fall back to pushing over HTTPS with the API token in
-#                the URL only when there is no SSH setup and no credential helper
-#                (e.g. CI with just GITHUB_TOKEN). (default)
-#   user_creds — never use the API token for git. Pushes with your own credentials
-#                only; this avoids needing the `workflow` token scope to push
-#                .github/workflows files.
-#   token      — always push over HTTPS with the API token in the URL. For CI where
-#                the token was granted the `workflow` scope intentionally.
-# mode = auto
+# How git push/clone authenticates for --local / --from: auto | user_creds | token
+#   auto       — your own credentials (SSH key or credential helper) when available;
+#                fall back to HTTPS with the API token in the URL only when there is
+#                no SSH setup and no credential helper (e.g. CI with GITHUB_TOKEN)
+#   user_creds — never use the API token for git; avoids needing the `workflow`
+#                scope to push .github/workflows files
+#   token      — always HTTPS with the API token in the URL, for CI that granted
+#                the `workflow` scope intentionally
+mode = auto
 ```
 
----
-
-## GitHub Plan Limitations
+### GitHub plan limitations
 
 Some features are only available depending on repo visibility and your GitHub plan.
 
@@ -756,9 +594,7 @@ Some features are only available depending on repo visibility and your GitHub pl
 
 `gh-safe-repo` detects your plan level and repo visibility at runtime. Unavailable features appear as `SKIP` in the plan output with a clear reason — the tool never fails silently.
 
----
-
-## How It Works
+### How it works
 
 ```
 gh-safe-repo create <owner/repo>
@@ -794,56 +630,31 @@ gh-safe-repo create <owner/repo>
               or git init + add -A + commit + push (if --local, plain dir)
 ```
 
-### Plugin architecture
+Each category of settings is a self-contained plugin (`gh_safe_repo/plugins/`) that fetches current state, diffs it against config, returns a `Plan`, and applies only real changes. Create mode and audit mode therefore share one code path — the only difference is whether current state comes from an existing repo or from GitHub's defaults. See [`gh_safe_repo/README.md`](gh_safe_repo/README.md) for the module map and a guide to adding new settings.
 
-Each category of settings is a self-contained plugin class (`gh_safe_repo/plugins/`). Every plugin:
-
-1. Fetches current state from the GitHub API
-2. Compares against desired state from config
-3. Returns a `Plan` (list of `Change` objects: ADD / UPDATE / DELETE / SKIP)
-4. Applies only real changes — no API calls for no-ops
-
-This means audit mode and create mode use the same plan/apply path. The only difference is whether current state is fetched from an existing repo or assumed to be GitHub defaults.
-
-### Authentication
-
-API calls resolve a token in this order:
+**Authentication.** API calls resolve a token in this order:
 
 1. `GITHUB_TOKEN` environment variable — lets you target a specific account without switching the active `gh` session (and is the only credential needed in CI)
 2. `gh auth token` — whatever `gh auth login` set up
 3. Error if neither is available
 
-Tokens are passed to child `gh api` processes as `GH_TOKEN` in the subprocess environment and are never logged.
+Tokens are passed to child `gh api` processes as `GH_TOKEN` in the subprocess environment and are never logged. Git operations use your own credentials instead — see [Working from local or existing code](#working-from-local-or-existing-code). Token-bearing URLs are never written to your repo's `.git/config` and are redacted from all output.
 
-Git operations (`--local` / `--from` push and clone) use your own git credentials — SSH key or credential helper — by default, not the API token. In environments with neither (e.g. CI with only `GITHUB_TOKEN`), the tool falls back to pushing over HTTPS with the token in the URL; the `[git_transport] mode` config setting controls this (see the configuration reference). Token-bearing URLs are never written to your repo's `.git/config` and are redacted from all output.
+**API approach.** All GitHub API calls go through `gh api` via `subprocess`. This keeps authentication entirely in the `gh` CLI — no token management code, no OAuth flow, no PyGithub version pinning. JSON request bodies are passed via `--input -` (stdin), not `--field` flags.
 
-### API approach
-
-All GitHub API calls go through `gh api` via `subprocess`. This keeps authentication entirely in the `gh` CLI — no token management code, no OAuth flow, no PyGithub version pinning. JSON request bodies are passed via `--input -` (stdin), not `--field` flags.
-
----
-
-## Development
+### Development
 
 ```bash
-# Clone and set up
-git clone https://github.com/your-username/gh-safe-repo
+git clone https://github.com/AriESQ/gh-safe-repo
 cd gh-safe-repo
 uv sync                          # creates .venv, installs pytest
 
-# Run tests
-uv run pytest tests/ -v
-
-# Run the tool directly (without installing)
-./gh-safe-repo create <owner/repo> --dry-run
-
-# Install globally (picks up the current source)
-uv tool install .
+uv run pytest tests/ -v          # run tests
+./gh-safe-repo create <owner/repo> --dry-run   # run without installing
+uv tool install .                # install globally from current source
 ```
 
-See [`tests/README.md`](tests/README.md) for test file descriptions, mocking conventions, and how to add new tests.
-
-### Project structure
+There are **no runtime dependencies** — everything uses the standard library (`argparse`, `configparser`, `subprocess`, `json`, `re`). Do not add third-party packages without discussion. `pytest` is the only dev dependency, declared as a UV-native `[dependency-groups]` entry in `pyproject.toml`.
 
 ```
 gh-safe-repo/
@@ -861,17 +672,9 @@ gh-safe-repo/
 └── tests/
 ```
 
-See [`gh_safe_repo/README.md`](gh_safe_repo/README.md) for the module map, plugin architecture, and a guide to adding new settings.
+See [`tests/README.md`](tests/README.md) for test file descriptions, mocking conventions, and how to add new tests, and [`gh_safe_repo/README.md`](gh_safe_repo/README.md) for the module map and plugin architecture.
 
-### Dependency policy
-
-There are **no runtime dependencies**. Everything uses the Python standard library (`argparse`, `configparser`, `subprocess`, `json`, `re`). Do not add third-party packages without discussion.
-
-`pytest` is the only dev dependency, declared as a UV-native `[dependency-groups]` entry in `pyproject.toml`.
-
----
-
-## Prior Art
+### Prior art
 
 These projects were studied during design and influenced the architecture of `gh-safe-repo`. They are distinct tools with different scope and user models — see [docs/LEARNINGS.md](docs/LEARNINGS.md) for detailed technical notes on how patterns were adapted.
 
@@ -880,4 +683,3 @@ These projects were studied during design and influenced the architecture of `gh
 - **[repository-settings/app](https://github.com/repository-settings/app)** — Simpler per-repo variant of safe-settings, also Node.js/Probot. Provided a cleaner reference for the `Diffable` base plugin pattern.
 
 - **[nicholasgasior/gh-repo-settings](https://github.com/nicholasgasior/gh-repo-settings)** — CLI extension written in Go with a `plan`/`apply` workflow. Primary inspiration for the `gh api` subprocess wrapper pattern and the dry-run plan output design.
-


### PR DESCRIPTION
## What

Restructures `README.md` so the most important information is at the top and reference material is organized below it. 883 → 685 lines.

**Part 1 — getting started (first ~120 lines):** pitch → `Status:` callout → **What you get** (bulleted summary) → **Requirements** → **Install** → **Your first repo** (preview → apply → success banner) → **Common tasks** (one short section per workflow: `create`, `--local`, `--from`, `fix`, `scan`).

**Part 2 — everything below a single `## Reference` divider:** CLI options, plan/JSON output, the full defaults tables, `--local`/`--from` mechanics, scanner, configuration, plan limitations, how it works, development, prior art.

**Trimmed:** the `[pre_flight_scan]` ini block duplicated between the scanner section and the config reference, comments that merely restated key names, and plugin-architecture prose already covered in `gh_safe_repo/README.md`. Dropped the hand-maintained 20-entry ToC — GitHub renders an auto-outline.

## Stale content corrected

Found while cross-checking every claim against the code:

- **Python 3.8+ → 3.10+** — `pyproject.toml` says `requires-python = ">=3.10"`
- **Dry-run sample was stale** — real columns are `Type / Category / Setting / Value / Note`, not `Category / Action / Setting / Value`. Replaced with verbatim captured output.
- **Clone URLs** — `github.com/your-username/...` → the real remote
- **`--migrate-branch-protection`** was missing from the `fix` option table
- **Config reference drift** — `protected_branch` default is `master, main` not `main`; `[actions] enabled` and `fork_pr_approval_policy` were missing; `scan_email_history`, `warn_ai_context_files`, `trufflehog_mode` and `[git_transport] mode` were shown as commented-out optionals despite being active defaults

## ⚠️ One behavioural claim changed — worth a look

The README said wiki and projects are **disabled by default**, including in the headline pitch. They aren't: 9458d35 ("Make has_wiki, has_issues, has_projects opt-in rather than managed by default") changed this and the docs were never updated. A `create --dry-run` emits no `has_wiki` row, confirming it.

They're now documented as opt-in (`has_wiki = false` in `[repo]`). If the intent was for them to stay disabled by default, the fix belongs in `SAFE_DEFAULTS` rather than in the docs.

## Verification

- All 35 headings and every `](#anchor)` resolve; all 4 relative links exist
- Every `SAFE_DEFAULTS` key cross-checked programmatically against the README ini block — no missing keys, no value mismatches
- `uv run pytest tests/test_config_consistency.py` — 140 passed
- Full suite: 551 passed, 7 skipped, 3 failed. The 3 failures (`test_scan_exclude_paths_applies_to_history`, `TestSkipDirsGitAware::test_committed_skip_dir_is_scanned{,_nested}`) are **pre-existing** — they fail identically with this branch's README stashed, on a `git commit` inside a pytest temp repo.

Docs only — no code, config, or other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
