### PR TITLE
Accept --config and --debug before the command; tidy top-level --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file was introduced with 0.2.0; the 0.2.0 entry backfills notable changes
 since the initial release.
 
+## [0.6.0] - 2026-08-20
+
+### Changed
+- `--config` and `--debug` are now global options: they are accepted before the
+  command (`gh-safe-repo --debug fix owner/repo`) as well as after it, matching
+  the convention used by `git`, `docker`, and `kubectl`. Previously only the
+  post-command form parsed; the pre-command form failed with "unrecognized
+  arguments". Existing invocations are unaffected. If both positions are used,
+  the later one wins.
+- Top-level `--help` lists `--config` and `--debug` under the `options:` heading
+  instead of as a trailing line of the description, and colors the `usage:` and
+  `examples:` headings to match argparse's own section headings.
+
 ## [0.5.0] - 2026-07-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -178,10 +178,17 @@ See [Pre-flight security scanner](#pre-flight-security-scanner).
 ### CLI reference
 
 ```
-gh-safe-repo create <owner/repo> [OPTIONS]
-gh-safe-repo fix <owner/repo> [OPTIONS]
-gh-safe-repo scan <path> [OPTIONS]
+gh-safe-repo [--config PATH] [--debug] create <owner/repo> [OPTIONS]
+gh-safe-repo [--config PATH] [--debug] fix <owner/repo> [OPTIONS]
+gh-safe-repo [--config PATH] [--debug] scan <path> [OPTIONS]
 ```
+
+`--config` and `--debug` are global: they may be given before or after the
+command (`gh-safe-repo --debug fix owner/repo` and
+`gh-safe-repo fix owner/repo --debug` are equivalent), and the later one wins
+if both are given. All other options are command-specific and must follow the
+command. Note that `--config` takes an optional value, so a bare `--config`
+should come last — `gh-safe-repo --config scan ./src` reads `scan` as the path.
 
 All commands that interact with GitHub require the `owner/repo` format (e.g. `myuser/my-repo`). For `create`, the owner is validated against your authenticated GitHub account to prevent mistakes on multi-account systems. For `fix`, admin permissions on the target repo are required instead, allowing you to fix repos owned by organizations or other accounts where you have admin access.
 
@@ -195,8 +202,8 @@ All commands that interact with GitHub require the `owner/repo` format (e.g. `my
 | `--yes` / `-y` | Skip confirmation prompt and apply immediately (for scripting/batch use) |
 | `--dry-run` | Print the plan without making any changes |
 | `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Print every API call and response |
+| `--config [PATH]` | *(global)* Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | *(global)* Print every API call and response |
 
 #### `fix` — audit and fix an existing repo
 
@@ -206,15 +213,15 @@ All commands that interact with GitHub require the `owner/repo` format (e.g. `my
 | `--dry-run` | Show settings diff without applying changes |
 | `--migrate-branch-protection` | Convert existing classic branch protection to a ruleset (see [Branch protection](#branch-protection-public-repos-or-any-repo-on-a-paid-plan)) |
 | `--json` | Emit the plan as JSON to stdout instead of the ANSI table |
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Print every API call and response, plus resolved repo identity (id, full name, owner type) |
+| `--config [PATH]` | *(global)* Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | *(global)* Print every API call and response, plus resolved repo identity (id, full name, owner type) |
 
 #### `scan` — local secret scanning
 
 | Option | Description |
 |---|---|
-| `--config [PATH]` | Path to config file; bare `--config` uses built-in defaults only |
-| `--debug` | Show scanner details |
+| `--config [PATH]` | *(global)* Path to config file; bare `--config` uses built-in defaults only |
+| `--debug` | *(global)* Show scanner details |
 
 Exit code is `0` if no critical findings, `1` if criticals are found.
 

--- a/docs/MANUAL_TESTING.md
+++ b/docs/MANUAL_TESTING.md
@@ -29,19 +29,33 @@ gh-safe-repo --help
 **Expected output (approximately):**
 
 ```
-usage: gh-safe-repo [-h] {create,fix,scan} ...
+usage: gh-safe-repo [--config PATH] [--debug] <command> [options]
 
-Create GitHub repositories with safe defaults applied.
+Manage safe defaults for GitHub repositories.
 
-positional arguments:
-  {create,fix,scan}
-    create           Create a new repo with safe defaults
-    fix              Audit an existing repo and apply safe defaults
-    scan             Scan a local directory for secrets (no GitHub interaction)
+usage:
+  gh-safe-repo create <owner/repo> [--public] [--local PATH | --from OWNER/REPO] [--dry-run]
+  gh-safe-repo fix   <owner/repo>  [--yes] [--dry-run]
+  gh-safe-repo scan  <path>
+
+commands:
+
+    create         Create a new repo with safe defaults
+    fix            Audit an existing repo and apply safe defaults
+    scan           Scan a local directory for secrets (no GitHub interaction)
 
 options:
-  -h, --help         show this help message and exit
+  -h, --help       show this help message and exit
+  --debug          Show every API call made
+  --config [PATH]  Path to config file; bare --config uses built-in defaults
+                   only
+
+examples:
+  ...
 ```
+
+The `usage:`, `commands:`, `options:` and `examples:` headings are bold blue on
+a color-capable terminal, and plain when piped or under `NO_COLOR`.
 
 ### 0.3 Subcommand help
 
@@ -51,7 +65,16 @@ gh-safe-repo fix --help
 gh-safe-repo scan --help
 ```
 
-**Expected:** Each subcommand shows its own arguments (e.g. `create` shows `--public`, `--local`, `--from`, `--yes`; `fix` shows `--yes`; `scan` has no `--dry-run`).
+**Expected:** Each subcommand shows its own arguments (e.g. `create` shows `--public`, `--local`, `--from`, `--yes`; `fix` shows `--yes`; `scan` has no `--dry-run`). Each also lists the global `--config` / `--debug`.
+
+### 0.4 Global options on either side of the command
+
+```bash
+gh-safe-repo --debug scan ./src
+gh-safe-repo scan ./src --debug
+```
+
+**Expected:** Both print `[debug] config: ...` to stderr. The same applies to `--config`.
 
 ### 0.4 No subcommand shows help
 

--- a/gh_safe_repo/README.md
+++ b/gh_safe_repo/README.md
@@ -20,8 +20,8 @@ gh_safe_repo/         ← this package (all real logic lives here)
 
 | Module | Purpose |
 |---|---|
-| `cli.py` | `main()` — subparser dispatch to `create`, `fix`, `scan` commands |
-| `commands/_common.py` | Shared helpers: `CLIContext`, `parse_repo_arg()`, `build_context()`, plan formatting, ANSI output |
+| `cli.py` | `build_parser()` / `main()` — subparser dispatch to `create`, `fix`, `scan` commands |
+| `commands/_common.py` | Shared helpers: `CLIContext`, `parse_repo_arg()`, `build_context()`, `add_common_args()`, plan formatting, ANSI output |
 | `commands/create.py` | `create` subcommand — new repo with safe defaults |
 | `commands/fix.py` | `fix` subcommand — audit existing repo, show diff, apply corrections |
 | `commands/scan.py` | `scan` subcommand — local-only secret scanning |
@@ -37,6 +37,17 @@ gh_safe_repo/         ← this package (all real logic lives here)
 | `plugins/security.py` | Dependabot alerts/security updates, secret scanning/push protection, private vuln reporting |
 | `plugins/tag_protection.py` | Immutable tags via Rulesets API (prevent deletion/rewriting of release tags) |
 | `templates/` | File templates (currently empty) |
+
+## Global vs. command options
+
+`--config` and `--debug` are parsed on either side of the command name. They are
+registered twice: once on the top-level parser (`build_parser()`, with the real
+defaults) and once on each subparser (`add_common_args()`, with
+`default=argparse.SUPPRESS`). The SUPPRESS is what makes the pre-command form
+usable — without it, the subparser's own default overwrites the value the
+top-level parser already stored in the namespace. Any new global option must
+follow the same two-sided pattern; command-specific options (`--json`,
+`--dry-run`, …) stay on their subparser with a normal default.
 
 ## Plugin architecture
 

--- a/gh_safe_repo/cli.py
+++ b/gh_safe_repo/cli.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 
 from .commands import create, fix, scan
+from .commands._common import add_common_args
 
 
 def _heading_style():
@@ -40,7 +41,8 @@ def _options_last(parser):
             break
 
 
-def main():
+def build_parser():
+    """Build the top-level parser with its three subcommands."""
     h, r = _heading_style()
     parser = argparse.ArgumentParser(
         prog="gh-safe-repo",
@@ -50,9 +52,7 @@ Manage safe defaults for GitHub repositories.
 {h}usage:{r}
   gh-safe-repo create <owner/repo> [--public] [--local PATH | --from OWNER/REPO] [--dry-run]
   gh-safe-repo fix   <owner/repo>  [--yes] [--dry-run]
-  gh-safe-repo scan  <path>
-
-common options: --config PATH, --debug""",
+  gh-safe-repo scan  <path>""",
         epilog=f"""\
 {h}examples:{r}
   gh-safe-repo create <owner/repo>                    Create a private repo
@@ -66,8 +66,12 @@ common options: --config PATH, --debug""",
   gh-safe-repo scan ./src                             Scan a local directory for secrets
 """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage="gh-safe-repo <command> [options]",
+        usage="gh-safe-repo [--config PATH] [--debug] <command> [options]",
     )
+    # Global: also added to every subparser, so they work on either side of
+    # the command (`--debug create ...` as well as `create ... --debug`).
+    add_common_args(parser, json_flag=False, global_defaults=True)
+
     subparsers = parser.add_subparsers(dest="command", title="commands", metavar="")
 
     for cmd_module in (create, fix, scan):
@@ -84,6 +88,11 @@ common options: --config PATH, --debug""",
     # Move commands before options in top-level help
     _options_last(parser)
 
+    return parser
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
     if not hasattr(args, "func"):

--- a/gh_safe_repo/cli.py
+++ b/gh_safe_repo/cli.py
@@ -13,6 +13,23 @@ import sys
 from .commands import create, fix, scan
 
 
+def _heading_style():
+    """Return (color, reset) matching argparse's own section headings.
+
+    Empty strings when color is unavailable (Python < 3.14) or disabled
+    (NO_COLOR, non-tty), so raw description/epilog text stays plain in the
+    same cases argparse itself drops color.
+    """
+    try:
+        from _colorize import can_colorize, get_theme
+    except ImportError:
+        return "", ""
+    if not can_colorize():
+        return "", ""
+    theme = get_theme(force_color=True).argparse
+    return theme.heading, theme.reset
+
+
 def _options_last(parser):
     """Reorder action groups so 'options' appears last in --help output."""
     # _action_groups is [positionals, optionals, ...extra]. Move optionals to end.
@@ -24,19 +41,20 @@ def _options_last(parser):
 
 
 def main():
+    h, r = _heading_style()
     parser = argparse.ArgumentParser(
         prog="gh-safe-repo",
-        description="""\
+        description=f"""\
 Manage safe defaults for GitHub repositories.
 
-usage:
+{h}usage:{r}
   gh-safe-repo create <owner/repo> [--public] [--local PATH | --from OWNER/REPO] [--dry-run]
   gh-safe-repo fix   <owner/repo>  [--yes] [--dry-run]
   gh-safe-repo scan  <path>
 
 common options: --config PATH, --debug""",
-        epilog="""\
-examples:
+        epilog=f"""\
+{h}examples:{r}
   gh-safe-repo create <owner/repo>                    Create a private repo
   gh-safe-repo create <owner/repo> --public           Create a public repo
   gh-safe-repo create <owner/repo> --local ./src      Push local code to a new repo

--- a/gh_safe_repo/commands/_common.py
+++ b/gh_safe_repo/commands/_common.py
@@ -1,5 +1,6 @@
 """Shared helpers for CLI subcommands."""
 
+import argparse
 import json
 import os
 import re
@@ -116,12 +117,22 @@ def build_context(args, expected_owner, require_owner_match=True):
     )
 
 
-def add_common_args(parser):
-    """Add --debug, --config, --json to a subparser."""
+def add_common_args(parser, *, json_flag=True, global_defaults=False):
+    """Add --debug and --config (and --json) to a parser.
+
+    These two are global: `cli.main` also adds them to the top-level parser so
+    they work on either side of the command (`--debug create ...` and
+    `create ... --debug`). On the subparsers they carry `default=SUPPRESS` so
+    an unused subparser default cannot clobber a value already parsed before
+    the command; the top-level copies (`global_defaults=True`) supply the
+    fallback values. --json stays command-local and keeps a real default.
+    """
+    default = {} if global_defaults else {"default": argparse.SUPPRESS}
     parser.add_argument(
         "--debug",
         action="store_true",
         help="Show every API call made",
+        **default,
     )
     parser.add_argument(
         "--config",
@@ -129,12 +140,14 @@ def add_common_args(parser):
         const="",
         metavar="PATH",
         help="Path to config file; bare --config uses built-in defaults only",
+        **default,
     )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit the plan as JSON instead of the ANSI table",
-    )
+    if json_flag:
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit the plan as JSON instead of the ANSI table",
+        )
 
 
 def info(msg, *, json_mode=False):

--- a/gh_safe_repo/commands/scan.py
+++ b/gh_safe_repo/commands/scan.py
@@ -13,6 +13,7 @@ from ._common import (
     _YELLOW,
     _c,
     _print_findings,
+    add_common_args,
     error,
 )
 
@@ -25,18 +26,7 @@ def add_arguments(parser):
         "path",
         help="Local directory path to scan",
     )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Show scanner details",
-    )
-    parser.add_argument(
-        "--config",
-        nargs="?",
-        const="",
-        metavar="PATH",
-        help="Path to config file; bare --config uses built-in defaults only",
-    )
+    add_common_args(parser, json_flag=False)
 
 
 def run(args):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gh-safe-repo"
-version = "0.5.0"
+version = "0.6.0"
 description = "Create GitHub repositories with safe defaults applied"
 requires-python = ">=3.10"
 

--- a/tests/e2e/test_input_validation.py
+++ b/tests/e2e/test_input_validation.py
@@ -46,6 +46,18 @@ class TestHelpOutput:
         assert r.returncode == 0
         assert "path" in r.stdout.lower()
 
+    def test_top_level_help_lists_global_options(self):
+        r = run("--help")
+        assert r.returncode == 0
+        assert "--config" in r.stdout
+        assert "--debug" in r.stdout
+
+    def test_global_debug_before_command(self, tmp_path):
+        """--debug must work before the command, not just after it."""
+        r = run("--debug", "scan", str(tmp_path))
+        assert r.returncode == 0
+        assert "[debug]" in r.stderr
+
 
 # ── Section 0.5 / 0.6: Bad repo arguments ───────────────────────────
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from gh_safe_repo.commands._common import (
     parse_repo_arg,
     print_success,
 )
-from gh_safe_repo.cli import main
+from gh_safe_repo.cli import build_parser, main
 from gh_safe_repo.commands import create, fix, scan
 from gh_safe_repo.config_manager import ConfigManager
 from gh_safe_repo.diff import Change, ChangeCategory, ChangeType, Plan
@@ -510,6 +510,51 @@ class TestNoSubcommand:
             with pytest.raises(SystemExit) as exc_info:
                 main()
         assert exc_info.value.code == 2
+
+
+class TestGlobalOptionPosition:
+    """--config and --debug are accepted on either side of the command.
+
+    They are registered on the top-level parser *and* on every subparser; the
+    subparser copies use default=SUPPRESS so an unused default cannot wipe out
+    a value parsed before the command.
+    """
+
+    @pytest.mark.parametrize("argv", [
+        ["--debug", "scan", "./src"],
+        ["scan", "--debug", "./src"],
+        ["scan", "./src", "--debug"],
+    ])
+    def test_debug_accepted_in_any_position(self, argv):
+        args = build_parser().parse_args(argv)
+        assert args.debug is True
+
+    @pytest.mark.parametrize("argv", [
+        ["--config", "a.ini", "scan", "./src"],
+        ["scan", "--config", "a.ini", "./src"],
+    ])
+    def test_config_accepted_in_any_position(self, argv):
+        args = build_parser().parse_args(argv)
+        assert args.config == "a.ini"
+
+    @pytest.mark.parametrize("command,rest", [
+        ("create", ["alice/repo"]),
+        ("fix", ["alice/repo"]),
+        ("scan", ["./src"]),
+    ])
+    def test_defaults_present_for_every_command(self, command, rest):
+        """SUPPRESS on the subparsers must not leave the attributes missing."""
+        args = build_parser().parse_args([command, *rest])
+        assert args.debug is False
+        assert args.config is None
+
+    def test_bare_config_uses_defaults_sentinel(self):
+        args = build_parser().parse_args(["scan", "./src", "--config"])
+        assert args.config == ""
+
+    def test_command_side_value_wins_over_global(self):
+        args = build_parser().parse_args(["--config", "a.ini", "scan", "./src", "--config", "b.ini"])
+        assert args.config == "b.ini"
 
 
 class TestFormatPlanJson:

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "gh-safe-repo"
-version = "0.3.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Makes `--config` and `--debug` behave like the global options they already were in spirit, and tidies the top-level `--help`.

Before, both flags were registered only on the subparsers, so the conventional pre-command form failed:

```
$ gh-safe-repo --debug create alice/repo
gh-safe-repo: error: unrecognized arguments: --debug
```

That is the opposite of `git -C dir status`, `docker --log-level debug run`, `kubectl -n ns get`, and of any Cobra persistent flag. Both positions now work, and the later occurrence wins if both are used.

## Changes

- **`Color the usage and examples headings in --help`** — the `usage:` and `examples:` headings live inside the raw description/epilog, so argparse never colored them and they looked unrelated to the `commands:`/`options:` headings it renders itself. They now pull the same bold blue from argparse's own theme, and fall back to plain text when color is unavailable (Python < 3.14) or disabled (`NO_COLOR`, piped output).
- **`Accept --config and --debug before the command`** — both flags are registered on the top-level parser as well as on each subparser. The subparser copies carry `default=argparse.SUPPRESS`, which is what makes the pre-command form usable: without it, the subparser's unused default overwrites the value the top-level parser already stored. `scan`'s hand-rolled copies are replaced by `add_common_args(json_flag=False)`, so all three commands share one definition. `build_parser()` is split out of `main()` so parsing is testable without a subprocess. As a side effect the two flags now appear under the `options:` heading with `-h/--help`, rather than as a trailing line of the description.
- **`Test and document …`** — see below.
- **`Release 0.6.0`** — minor bump; `uv.lock` still recorded `0.3.0` and is regenerated.

## Help output

```
usage: gh-safe-repo [--config PATH] [--debug] <command> [options]

Manage safe defaults for GitHub repositories.

usage:
  gh-safe-repo create <owner/repo> [--public] [--local PATH | --from OWNER/REPO] [--dry-run]
  gh-safe-repo fix   <owner/repo>  [--yes] [--dry-run]
  gh-safe-repo scan  <path>

commands:

    create         Create a new repo with safe defaults
    fix            Audit an existing repo and apply safe defaults
    scan           Scan a local directory for secrets (no GitHub interaction)

options:
  -h, --help       show this help message and exit
  --debug          Show every API call made
  --config [PATH]  Path to config file; bare --config uses built-in defaults
                   only
```

## Tests

- `tests/test_cli.py::TestGlobalOptionPosition` — `--debug` in all three positions, `--config` before/after the command, both attributes present for all three commands (guards the `SUPPRESS` defaults), bare `--config` → `""`, last-occurrence-wins.
- `tests/e2e/test_input_validation.py` — top-level help lists both flags; `--debug scan <dir>` reaches the real binary.
- 231 passed, 7 skipped across `test_cli.py`, `e2e`, and `test_config_consistency.py`. `test_security_scanner.py` has 3 failures that are pre-existing on `master` and untouched by this branch (`TestEmailHistoryScanning::test_scan_exclude_paths_applies_to_history`, `TestSkipDirsGitAware::test_committed_skip_dir_is_scanned{,_nested}`).

## Docs

`README.md` shows the global flags in the usage lines and marks them in each command's option table, including the one sharp edge: `--config` takes an optional value, so a bare `--config` should come last (`gh-safe-repo --config scan ./src` reads `scan` as the path — that was already true after the verb). `gh_safe_repo/README.md` documents the two-sided registration pattern so future global options follow it. `docs/MANUAL_TESTING.md` §0.2's expected `--help` transcript was stale — it still showed argparse's stock layout from before the custom usage/description — so it is refreshed, with a new §0.4 for both flag positions.

## Compatibility

Additive. Every existing invocation parses exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
